### PR TITLE
[Refactor] RAG pipeline 정리 및 응답 일관성 개선

### DIFF
--- a/apps/backend/api/README.md
+++ b/apps/backend/api/README.md
@@ -15,8 +15,8 @@ Legal AI Assistant FastAPI 백엔드 서버.
 cd apps/backend/api
 cp ../rag/.env.example .env   # 최초 1회 — LLM 환경변수 추가 필요 (하단 참조)
 
-uv run dev      # 개발 서버 (--reload)
-uv run start    # 운영 서버
+uv run uvicorn main:app --reload                    # 개발 서버
+uv run uvicorn main:app --host 0.0.0.0 --port 8000  # 운영 서버
 ```
 
 ## 환경변수

--- a/apps/backend/api/main.py
+++ b/apps/backend/api/main.py
@@ -8,8 +8,11 @@ from dotenv import load_dotenv
 
 load_dotenv(override=True)
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from src.retrieval.common import RetrievalError
 from src.routers import health, qa
 
 app = FastAPI(
@@ -24,6 +27,39 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request: Request, exc: RequestValidationError):
+    return JSONResponse(
+        status_code=422,
+        content={"code": "VALIDATION_ERROR", "error": exc.errors()[0]["msg"]},
+    )
+
+
+@app.exception_handler(HTTPException)
+async def http_exception_handler(request: Request, exc: HTTPException):
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"code": "HTTP_ERROR", "error": exc.detail},
+    )
+
+
+@app.exception_handler(RetrievalError)
+async def retrieval_exception_handler(request: Request, exc: RetrievalError):
+    return JSONResponse(
+        status_code=503,
+        content={"code": "PIPELINE_ERROR", "error": str(exc)},
+    )
+
+
+@app.exception_handler(Exception)
+async def internal_exception_handler(request: Request, exc: Exception):
+    return JSONResponse(
+        status_code=500,
+        content={"code": "INTERNAL_ERROR", "error": "서버 오류가 발생했습니다."},
+    )
+
 
 app.include_router(health.router)
 app.include_router(qa.router, prefix="/api/v1/qa")

--- a/apps/backend/api/pyproject.toml
+++ b/apps/backend/api/pyproject.toml
@@ -12,7 +12,3 @@ dependencies = [
 
 [tool.uv.sources]
 rag-pipeline = { path = "../rag", editable = true }
-
-[tool.uv.scripts]
-start = "uvicorn main:app --host 0.0.0.0 --port 8000"
-dev = "uvicorn main:app --reload --host 0.0.0.0 --port 8000"

--- a/apps/backend/api/src/routers/qa.py
+++ b/apps/backend/api/src/routers/qa.py
@@ -59,13 +59,14 @@ def ask_stream(
 ) -> StreamingResponse:
     """질문을 받아 RAG 파이프라인을 실행하고 답변을 SSE로 스트리밍합니다."""
     def generate():
-        for chunk in pipeline.stream(
+        meta, chunks = pipeline.stream(
             request.question,
             doc_types=request.doc_types,
             law_names=request.law_names,
-        ):
+        )
+        for chunk in chunks:
             yield f"data: {json.dumps({'type': 'chunk', 'content': chunk}, ensure_ascii=False)}\n\n"
-        yield f"data: {json.dumps({'type': 'done'})}\n\n"
+        yield f"data: {json.dumps({'type': 'done', 'sources': meta.sources, 'retrieved_docs': meta.retrieved_docs, 'law_context_status': meta.law_context_status, 'law_context_added': meta.law_context_added}, ensure_ascii=False)}\n\n"
 
     return StreamingResponse(
         generate(),

--- a/apps/backend/api/src/routers/qa.py
+++ b/apps/backend/api/src/routers/qa.py
@@ -6,7 +6,6 @@
 """
 
 import json
-from typing import Any
 
 from fastapi import APIRouter, Depends
 from fastapi.responses import StreamingResponse
@@ -14,6 +13,7 @@ from pydantic import BaseModel
 
 from src.dependencies import get_rag_pipeline
 from src.generation.pipeline import RagPipeline
+from src.retrieval.common import RetrievalError
 
 router = APIRouter(tags=["qa"])
 
@@ -24,12 +24,19 @@ class AskRequest(BaseModel):
     law_names: list[str] | None = None
 
 
+class RetrievedDoc(BaseModel):
+    rank: int
+    source_id: str
+    doc_type: str
+    law_name: str
+    score: float | None
+    snippet: str
+
+
 class AskResponse(BaseModel):
     answer: str
-    sources: list[dict[str, Any]]
-    retrieved_docs: list[dict[str, Any]]
+    retrieved_docs: list[RetrievedDoc]
     law_context_status: str
-    law_context_added: bool
 
 
 @router.post("/ask", response_model=AskResponse)
@@ -45,10 +52,8 @@ def ask(
     )
     return AskResponse(
         answer=result.answer,
-        sources=result.sources,
-        retrieved_docs=result.retrieved_docs,
+        retrieved_docs=[RetrievedDoc(**doc) for doc in result.retrieved_docs],
         law_context_status=result.law_context_status,
-        law_context_added=result.law_context_added,
     )
 
 
@@ -59,14 +64,24 @@ def ask_stream(
 ) -> StreamingResponse:
     """질문을 받아 RAG 파이프라인을 실행하고 답변을 SSE로 스트리밍합니다."""
     def generate():
-        meta, chunks = pipeline.stream(
-            request.question,
-            doc_types=request.doc_types,
-            law_names=request.law_names,
-        )
-        for chunk in chunks:
-            yield f"data: {json.dumps({'type': 'chunk', 'content': chunk}, ensure_ascii=False)}\n\n"
-        yield f"data: {json.dumps({'type': 'done', 'sources': meta.sources, 'retrieved_docs': meta.retrieved_docs, 'law_context_status': meta.law_context_status, 'law_context_added': meta.law_context_added}, ensure_ascii=False)}\n\n"
+        try:
+            meta, chunks = pipeline.stream(
+                request.question,
+                doc_types=request.doc_types,
+                law_names=request.law_names,
+            )
+            for chunk in chunks:
+                yield f"data: {json.dumps({'type': 'chunk', 'content': chunk}, ensure_ascii=False)}\n\n"
+            done_payload = {
+                "type": "done",
+                "retrieved_docs": [RetrievedDoc(**doc).model_dump() for doc in meta.retrieved_docs],
+                "law_context_status": meta.law_context_status,
+            }
+            yield f"data: {json.dumps(done_payload, ensure_ascii=False)}\n\n"
+        except RetrievalError as exc:
+            yield f"data: {json.dumps({'type': 'error', 'code': 'PIPELINE_ERROR', 'error': str(exc)}, ensure_ascii=False)}\n\n"
+        except Exception:
+            yield f"data: {json.dumps({'type': 'error', 'code': 'INTERNAL_ERROR', 'error': '서버 오류가 발생했습니다.'}, ensure_ascii=False)}\n\n"
 
     return StreamingResponse(
         generate(),

--- a/apps/backend/rag/src/generation/pipeline.py
+++ b/apps/backend/rag/src/generation/pipeline.py
@@ -260,9 +260,13 @@ class RagPipeline:
         system_prompt: str | None = DEFAULT_SYSTEM_PROMPT,
         doc_types: list[str] | None = None,
         law_names: list[str] | None = None,
-    ) -> Iterator[str]:
-        """검색 후 생성을 스트리밍으로 반환한다. 토큰 조각을 순차 yield한다."""
-        llm_rows, context_text, law_context_status, _ = self._retrieve(
+    ) -> tuple[RagResult, Iterator[str]]:
+        """검색 후 생성을 스트리밍으로 반환한다.
+
+        Returns:
+            (meta, chunks): meta는 sources 등 메타데이터, chunks는 토큰 조각 이터레이터.
+        """
+        llm_rows, context_text, law_context_status, law_context_added = self._retrieve(
             question, doc_types=doc_types, law_names=law_names
         )
         prompt = build_user_prompt_with_limit(
@@ -271,4 +275,5 @@ class RagPipeline:
             max_input_chars=self._cfg.max_input_chars,
             law_context_status=law_context_status,
         )
-        yield from self._generation.stream(prompt, system_prompt=system_prompt)
+        meta = self._build_result("", llm_rows, law_context_status, law_context_added)
+        return meta, self._generation.stream(prompt, system_prompt=system_prompt)

--- a/apps/backend/rag/src/generation/pipeline.py
+++ b/apps/backend/rag/src/generation/pipeline.py
@@ -50,10 +50,8 @@ class RagResult:
     """run() 반환값. API 응답으로 직렬화한다."""
 
     answer: str
-    sources: list[dict[str, Any]]        # 중복 제거된 출처 목록
-    retrieved_docs: list[dict[str, Any]] # 컨텍스트에 사용된 문서 목록
-    law_context_status: str              # "ok" | "missing" | "supplemented"
-    law_context_added: bool
+    retrieved_docs: list[dict[str, Any]]  # 컨텍스트에 사용된 문서 목록
+    law_context_status: str               # "ok" | "missing" | "supplemented"
 
 
 # ── 프롬프트 빌더 ─────────────────────────────────────────────────────────────
@@ -193,24 +191,8 @@ class RagPipeline:
         answer: str,
         llm_rows: list[dict[str, Any]],
         law_context_status: str,
-        law_context_added: bool,
     ) -> RagResult:
         snippet_max = self._cfg.snippet_max_chars
-
-        seen: set[str] = set()
-        sources: list[dict[str, Any]] = []
-        for row in llm_rows:
-            source_id = str(row.get("source_id", "") or "")
-            if not source_id or source_id in seen:
-                continue
-            seen.add(source_id)
-            sources.append({
-                "source_id": source_id,
-                "rank": row.get("rank"),
-                "doc_type": str(row.get("doc_type", "") or ""),
-                "law_name": str(row.get("law_name", "") or ""),
-                "score": row.get("score"),
-            })
 
         retrieved_docs = [
             {
@@ -226,10 +208,8 @@ class RagPipeline:
 
         return RagResult(
             answer=answer,
-            sources=sources,
             retrieved_docs=retrieved_docs,
             law_context_status=law_context_status,
-            law_context_added=law_context_added,
         )
 
     def run(
@@ -251,7 +231,7 @@ class RagPipeline:
             law_context_status=law_context_status,
         )
         result = self._generation.generate(prompt, system_prompt=system_prompt)
-        return self._build_result(result.answer, llm_rows, law_context_status, law_context_added)
+        return self._build_result(result.answer, llm_rows, law_context_status)
 
     def stream(
         self,
@@ -275,5 +255,5 @@ class RagPipeline:
             max_input_chars=self._cfg.max_input_chars,
             law_context_status=law_context_status,
         )
-        meta = self._build_result("", llm_rows, law_context_status, law_context_added)
+        meta = self._build_result("", llm_rows, law_context_status)
         return meta, self._generation.stream(prompt, system_prompt=system_prompt)

--- a/apps/backend/rag/src/retrieval/__init__.py
+++ b/apps/backend/rag/src/retrieval/__init__.py
@@ -12,14 +12,12 @@ from .fusion import fuse_rrf
 from .opensearch import search_bm25
 from .qdrant import search_qdrant
 from .ranking import apply_law_boost, is_normative_query, rank_rows, select_llm_rows, select_rows_with_law_policy
-from .service import RetrievalConfig, RetrievalResult, RetrievalService
+from .service import RetrievalConfig
 
 __all__ = [
     "DEFAULT_EMBEDDING_MODEL",
     "RetrievalConfig",
     "RetrievalError",
-    "RetrievalResult",
-    "RetrievalService",
     "apply_law_boost",
     "build_llm_context_rows",
     "build_llm_context_text",

--- a/apps/backend/rag/src/retrieval/service.py
+++ b/apps/backend/rag/src/retrieval/service.py
@@ -1,26 +1,15 @@
-"""검색 파이프라인 서비스.
-
-전체 retrieval 흐름을 조립한다:
-  search_qdrant + search_bm25 → fuse_rrf → apply_law_boost → select_llm_rows → build_llm_context_rows
-"""
+"""검색 파이프라인 설정 모듈."""
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
-from typing import Any
 
 from .common import DEFAULT_EMBEDDING_MODEL
-from .context import build_llm_context_rows
-from .fusion import fuse_rrf
-from .opensearch import search_bm25
-from .qdrant import search_qdrant
-from .ranking import apply_law_boost, select_llm_rows
 
 
 @dataclass
 class RetrievalConfig:
-    """RetrievalService 연결 및 파이프라인 설정."""
+    """RagPipeline retrieval 설정."""
 
     # 연결 정보
     qdrant_url: str
@@ -44,96 +33,3 @@ class RetrievalConfig:
     max_content_chars: int = 1200
     max_total_chars: int = 6000
 
-
-@dataclass
-class RetrievalResult:
-    """retrieve() 반환값."""
-
-    contexts: list[dict[str, Any]]
-    law_context_added: bool
-
-
-class RetrievalService:
-    def __init__(self, config: RetrievalConfig) -> None:
-        self._cfg = config
-
-    @classmethod
-    def from_env(cls) -> RetrievalService:
-        """환경변수에서 설정을 읽어 인스턴스를 생성한다."""
-        config = RetrievalConfig(
-            qdrant_url=os.environ["QDRANT_URL"],
-            qdrant_collection=os.environ["QDRANT_COLLECTION"],
-            qdrant_api_key=os.getenv("QDRANT_API_KEY") or None,
-            opensearch_url=os.environ["OPENSEARCH_URL"],
-            opensearch_index=os.environ["OPENSEARCH_INDEX"],
-            opensearch_api_key=os.getenv("OPENSEARCH_API_KEY") or None,
-            opensearch_username=os.getenv("OPENSEARCH_USERNAME") or None,
-            opensearch_password=os.getenv("OPENSEARCH_PASSWORD") or None,
-            embedding_model=os.getenv("EMBEDDING_MODEL", DEFAULT_EMBEDDING_MODEL),
-        )
-        return cls(config)
-
-    def retrieve(
-        self,
-        question: str,
-        *,
-        doc_types: list[str] | None = None,
-        law_names: list[str] | None = None,
-    ) -> RetrievalResult:
-        """질문에 대해 전체 검색 파이프라인을 실행하고 LLM 컨텍스트를 반환한다."""
-        cfg = self._cfg
-        candidate_k = max(cfg.top_k, cfg.candidate_k)
-
-        # 1. 벡터 검색 + BM25 검색
-        qdrant_rows = search_qdrant(
-            question,
-            candidate_k,
-            qdrant_url=cfg.qdrant_url,
-            collection=cfg.qdrant_collection,
-            timeout=cfg.timeout,
-            embedding_model=cfg.embedding_model,
-            api_key=cfg.qdrant_api_key,
-            doc_types=doc_types,
-            law_names=law_names,
-            dedup=True,
-            fetch_multiplier=2,
-        )
-        bm25_rows = search_bm25(
-            question,
-            candidate_k,
-            opensearch_url=cfg.opensearch_url,
-            index_name=cfg.opensearch_index,
-            timeout=cfg.timeout,
-            api_key=cfg.opensearch_api_key,
-            username=cfg.opensearch_username,
-            password=cfg.opensearch_password,
-            doc_types=doc_types,
-            law_names=law_names,
-            dedup=True,
-            fetch_multiplier=5,
-        )
-
-        # 2. RRF 융합
-        rrf_rows = fuse_rrf(qdrant_rows, bm25_rows, rrf_k=cfg.rrf_k, top_k=cfg.top_k)
-
-        # 3. Law 문서 점수 가산 후 재정렬
-        rrf_rows = apply_law_boost(
-            rrf_rows,
-            question=question,
-            enabled=cfg.auto_law_boost,
-            law_boost_score=cfg.law_boost_score,
-        )[: max(1, cfg.top_k)]
-
-        # 4. LLM 컨텍스트 빌드
-        llm_rows, law_context_added = select_llm_rows(
-            rrf_rows,
-            top_k=cfg.top_k,
-            min_law_contexts=cfg.min_law_contexts,
-        )
-        contexts = build_llm_context_rows(
-            llm_rows,
-            max_content_chars=cfg.max_content_chars,
-            max_total_chars=cfg.max_total_chars,
-        )
-
-        return RetrievalResult(contexts=contexts, law_context_added=law_context_added)


### PR DESCRIPTION
## Work Description
RAG 실행 구조를 단일 파이프라인(RagPipeline) 기준으로 정리하고, 스트리밍/비스트리밍 응답 간 메타데이터 일관성을 개선하여 런타임 안정성을 확보하였습니다.

## Changes
- 불필요한 RetrievalService를 제거하고 RagPipeline 단일 구조로 통합
- 서비스 레이어를 설정 중심으로 단순화하여 실행 흐름 정리
- 스트리밍(`/ask/stream`)과 비스트리밍(`/ask`) 응답 간 메타데이터 일관성 확보
- 스트리밍 응답에 sources, retrieved_docs 등 핵심 메타데이터 포함
- `/ask`, `/ask/stream` 응답 스키마 정리
- 에러 응답 포맷 표준화 (`VALIDATION_ERROR`/`PIPELINE_ERROR`/ `INTERNAL_ERROR`)

## Testing
- [x] 로컬 테스트 완료
- [x] 기능 동작 확인

## Related Issue
close #18
