### PR TITLE
[feature] 법령 본문간 조문 참조 관계 추출

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,6 +226,7 @@ apps/backend/doc-processor/tests/python-hwpx-docs/
 # legal-pipeline
 apps/backend/legal-pipeline/data/
 apps/backend/legal-pipeline/.local/
+apps/backend/legal-pipeline/CODEX.md
 
 # rag
 apps/backend/rag/docs/

--- a/apps/backend/legal-pipeline/scripts/upload/config.py
+++ b/apps/backend/legal-pipeline/scripts/upload/config.py
@@ -184,6 +184,9 @@ COLLECTION_KEYWORD_INDEX_FIELDS = {
         "relation_types",
         "relation_model_priority",
         "retrieval_role",
+        "source_article_key",
+        "source_article_no_display",
+        "resolution_status",
         "source_canonical_case_id",
         "target_canonical_case_id",
         "referenced_case_number",
@@ -193,13 +196,13 @@ COLLECTION_KEYWORD_INDEX_FIELDS = {
 COLLECTION_INTEGER_INDEX_FIELDS = {
     "law_article": COMMON_INTEGER_INDEX_FIELDS + ["related_appendix_count"],
     "legal_case": COMMON_INTEGER_INDEX_FIELDS,
-    "legal_relation": COMMON_INTEGER_INDEX_FIELDS,
+    "legal_relation": COMMON_INTEGER_INDEX_FIELDS + ["target_article_resolution_count"],
 }
 
 COLLECTION_FLOAT_INDEX_FIELDS = {
     "law_article": [],
     "legal_case": [],
-    "legal_relation": COMMON_FLOAT_INDEX_FIELDS,
+    "legal_relation": COMMON_FLOAT_INDEX_FIELDS + ["resolution_confidence"],
 }
 
 DROP_FIELDS_ON_EXTRACT = {

--- a/apps/backend/legal-pipeline/src/export/law_to_law_relation_builder.py
+++ b/apps/backend/legal-pipeline/src/export/law_to_law_relation_builder.py
@@ -10,6 +10,7 @@ from src.parser.legal_case_parser import (
     extract_explicit_article_refs,
     find_related_law_names,
 )
+from src.parser.law_reference_parser import parse_law_article_references
 
 
 def _normalize_space(text: str) -> str:
@@ -43,17 +44,56 @@ def _relation_text(row: dict[str, Any]) -> str:
     lines = [
         f"관계 모델: {row.get('relation_model') or ''}",
         f"출발 법령: {row.get('source_law_name') or ''}",
+        f"출발 조문: {row.get('source_article_no_display') or row.get('article_no_display') or ''}",
         f"대상 법령: {row.get('law_name') or ''}",
         f"관계 유형: {row.get('relation_type') or ''}",
+        f"해석 상태: {row.get('resolution_status') or ''}",
     ]
     article_displays = row.get("article_no_displays") or []
     if article_displays:
         lines.append(f"관련 조문: {', '.join(article_displays)}")
+    reference_texts = row.get("reference_texts") or []
+    if reference_texts:
+        lines.append(f"참조 표현: {', '.join(reference_texts)}")
     preview = str(row.get("display_text") or "").strip()
     if preview:
         lines.append("근거 일부:")
         lines.append(preview)
     return "\n".join(line for line in lines if line).strip()
+
+
+def _family_laws_by_alias(root_law_name: str, laws: list[dict[str, Any]]) -> dict[str, list[str]]:
+    alias_map: dict[str, list[str]] = {}
+
+    def add(alias: str, law_name: str) -> None:
+        key = "".join(str(alias or "").split())
+        value = str(law_name or "").strip()
+        if not key or not value:
+            return
+        alias_map.setdefault(key, [])
+        if value not in alias_map[key]:
+            alias_map[key].append(value)
+
+    for law in laws:
+        law_name = str(law.get("law_name") or "").strip()
+        if not law_name:
+            continue
+        add(law_name, law_name)
+        suffix = law_name
+        if root_law_name and law_name.startswith(root_law_name):
+            suffix = law_name[len(root_law_name):].strip()
+        if suffix and suffix != law_name:
+            add(suffix, law_name)
+    return alias_map
+
+
+def _relation_resolution_status(values: list[str]) -> str:
+    priority = ["resolved", "ambiguous", "unresolved_external", "unresolved"]
+    normalized = {str(value or "").strip() for value in values if str(value or "").strip()}
+    for candidate in priority:
+        if candidate in normalized:
+            return candidate
+    return "unresolved"
 
 
 def build_law_to_law_relation_records(
@@ -85,10 +125,25 @@ def build_law_to_law_relation_records(
         family_law_names = [row["law_name"] for row in laws]
         uid_by_name = {row["law_name"]: row["law_uid"] for row in laws}
         law_meta_by_name = {row["law_name"]: row for row in laws}
+        family_alias_map = _family_laws_by_alias(root_law_name, laws)
 
         for source in laws:
             payload = source["payload"]
-            for article in payload.get("articles", []) if isinstance(payload.get("articles"), list) else []:
+            articles = payload.get("articles", [])
+            article_order = [
+                {
+                    "article_key": str(
+                        article.get("article_key")
+                        or article.get("article_no_display")
+                        or article.get("article_no")
+                        or ""
+                    ).strip(),
+                    "article_no_display": str(article.get("article_no_display") or article.get("article_no") or "").strip(),
+                }
+                for article in articles
+                if isinstance(article, dict)
+            ]
+            for article in articles if isinstance(articles, list) else []:
                 if not isinstance(article, dict):
                     continue
 
@@ -102,34 +157,93 @@ def build_law_to_law_relation_records(
                 if not body_text:
                     continue
 
+                parsed_refs = parse_law_article_references(
+                    body_text,
+                    source_law_name=source["law_name"],
+                    source_law_level=payload.get("classified_level") or payload.get("kind_name"),
+                    source_article_key=article_key or None,
+                    article_order=article_order,
+                    root_law_name=root_law_name,
+                    family_laws=[
+                        {
+                            "law_name": row["law_name"],
+                            "classified_level": row["payload"].get("classified_level"),
+                            "kind_name": row["payload"].get("kind_name"),
+                        }
+                        for row in laws
+                    ],
+                )
                 matched_law_names = [
                     law_name
                     for law_name in find_related_law_names(body_text, family_law_names)
                     if law_name and law_name != source["law_name"]
                 ]
-                article_refs = extract_explicit_article_refs(body_text, family_law_names)
+                article_refs_map = extract_explicit_article_refs(body_text, family_law_names)
+
+                refs_by_target: dict[str, list[dict[str, Any]]] = defaultdict(list)
+                for reference in parsed_refs:
+                    target_law_name = str(reference.get("target_law_name") or "").strip()
+                    if not target_law_name:
+                        continue
+                    refs_by_target[target_law_name].append(reference)
 
                 for target_law_name in matched_law_names:
-                    target_law_uid = uid_by_name.get(target_law_name)
-                    if not target_law_uid:
-                        continue
+                    if target_law_name not in refs_by_target:
+                        refs_by_target[target_law_name].append(
+                            {
+                                "reference_type": "cited_law_name",
+                                "reference_text": target_law_name,
+                                "target_law_name": target_law_name,
+                                "related_law_names": family_alias_map.get("".join(target_law_name.split()), [target_law_name]),
+                                "target_article_keys": [],
+                                "target_article_no_displays": [],
+                                "resolution_status": "resolved",
+                                "resolution_confidence": 0.8,
+                            }
+                        )
 
-                    target_article_refs = article_refs.get(target_law_name, [])
-                    relation_type = "related_law" if target_article_refs else "cited_law"
-                    article_keys = [item["article_key"] for item in target_article_refs]
-                    article_no_displays = [item["article_no_display"] for item in target_article_refs]
+                for target_law_name, target_refs in sorted(refs_by_target.items()):
+                    target_meta = law_meta_by_name.get(target_law_name)
+                    target_law_uid = uid_by_name.get(target_law_name) if target_meta else None
+                    target_article_refs = article_refs_map.get(target_law_name, [])
+                    parsed_article_keys = [
+                        article_key
+                        for reference in target_refs
+                        for article_key in list(reference.get("target_article_keys") or [])
+                    ]
+                    parsed_article_no_displays = [
+                        article_no
+                        for reference in target_refs
+                        for article_no in list(reference.get("target_article_no_displays") or [])
+                    ]
+                    article_keys = list(dict.fromkeys(parsed_article_keys or [item["article_key"] for item in target_article_refs]))
+                    article_no_displays = list(
+                        dict.fromkeys(parsed_article_no_displays or [item["article_no_display"] for item in target_article_refs])
+                    )
+                    relation_type = "related_law" if article_keys else "cited_law"
+                    relation_status = _relation_resolution_status(
+                        [str(reference.get("resolution_status") or "") for reference in target_refs]
+                    )
+                    target_token = target_law_uid or f"external::{target_law_name.replace(' ', '_')}"
                     relation_id = "::".join(
                         [
                             "relation",
                             "law",
                             source["law_uid"],
-                            target_law_uid,
+                            target_token,
                             article_key or "root",
                         ]
                     )
                     current = merged.get(relation_id)
                     if current is None:
-                        target_meta = law_meta_by_name[target_law_name]
+                        relation_types = [relation_type]
+                        reference_types = {str(reference.get("reference_type") or "").strip() for reference in target_refs}
+                        if target_law_name == source["law_name"]:
+                            relation_types.append("same_law_reference")
+                        if any(reference_type in {"previous_article", "next_article", "current_article", "relative_scope"} for reference_type in reference_types):
+                            relation_types.append("relative_reference")
+                        if relation_status == "unresolved_external":
+                            relation_types.append("external_reference")
                         current = {
                             "id": relation_id,
                             "canonical_id": relation_id,
@@ -137,28 +251,58 @@ def build_law_to_law_relation_records(
                             "source_group": "01_current_law",
                             "relation_model": "law_to_law",
                             "relation_type": relation_type,
-                            "relation_types": [relation_type],
+                            "relation_types": list(dict.fromkeys(relation_types)),
                             "law_name": target_law_name,
                             "law_uid": target_law_uid,
                             "source_law_name": source["law_name"],
                             "source_law_uid": source["law_uid"],
                             "root_law_name": root_law_name,
                             "root_law_uid": source["root_law_uid"],
-                            "related_law_names": [target_law_name],
+                            "related_law_names": list(
+                                dict.fromkeys(
+                                    [target_law_name]
+                                    + [
+                                        candidate
+                                        for reference in target_refs
+                                        for candidate in list(reference.get("related_law_names") or [])
+                                        if str(candidate).strip()
+                                    ]
+                                )
+                            ),
                             "article_keys": article_keys,
                             "article_no_displays": article_no_displays,
-                            "relation_confidence": 0.95 if article_keys else 0.8,
+                            "relation_confidence": max(
+                                float(reference.get("resolution_confidence") or 0)
+                                for reference in target_refs
+                            ) if target_refs else (0.95 if article_keys else 0.8),
+                            "resolution_confidence": max(
+                                float(reference.get("resolution_confidence") or 0)
+                                for reference in target_refs
+                            ) if target_refs else (0.95 if article_keys else 0.8),
+                            "resolution_status": relation_status,
                             "title": f"{source['law_name']} -> {target_law_name}",
-                            "law_id": target_meta.get("law_id"),
-                            "mst": target_meta.get("mst"),
-                            "ef_yd": target_meta["payload"].get("ef_yd"),
-                            "kind_name": target_meta["payload"].get("kind_name"),
-                            "classified_level": target_meta["payload"].get("classified_level"),
-                            "law_level": target_meta["payload"].get("classified_level"),
+                            "law_id": target_meta.get("law_id") if target_meta else None,
+                            "mst": target_meta.get("mst") if target_meta else None,
+                            "ef_yd": target_meta["payload"].get("ef_yd") if target_meta else None,
+                            "kind_name": target_meta["payload"].get("kind_name") if target_meta else None,
+                            "classified_level": target_meta["payload"].get("classified_level") if target_meta else None,
+                            "law_level": target_meta["payload"].get("classified_level") if target_meta else None,
                             "source_hit_count": 1,
                             "section_type": "article",
                             "article_key": article_key or None,
                             "article_no_display": article.get("article_no_display") or article.get("article_no"),
+                            "source_article_key": article_key or None,
+                            "source_article_no_display": article.get("article_no_display") or article.get("article_no"),
+                            "target_article_resolution_count": len(article_keys),
+                            "reference_texts": list(
+                                dict.fromkeys(
+                                    [
+                                        str(reference.get("reference_text") or "").strip()
+                                        for reference in target_refs
+                                        if str(reference.get("reference_text") or "").strip()
+                                    ]
+                                )
+                            ),
                             "source_file_path": str(source["path"]),
                             "display_text": _truncate_text(body_text),
                         }
@@ -166,16 +310,52 @@ def build_law_to_law_relation_records(
                         continue
 
                     current["source_hit_count"] = int(current.get("source_hit_count") or 0) + 1
-                    current["relation_confidence"] = max(
-                        float(current.get("relation_confidence") or 0),
-                        0.95 if article_keys else 0.8,
+                    current["relation_confidence"] = max(float(current.get("relation_confidence") or 0), max(
+                        [float(reference.get("resolution_confidence") or 0) for reference in target_refs] or [0.95 if article_keys else 0.8]
+                    ))
+                    current["resolution_confidence"] = max(
+                        float(current.get("resolution_confidence") or 0),
+                        max([float(reference.get("resolution_confidence") or 0) for reference in target_refs] or [0.95 if article_keys else 0.8]),
                     )
                     current["article_keys"] = list(dict.fromkeys(list(current.get("article_keys", [])) + article_keys))
                     current["article_no_displays"] = list(
                         dict.fromkeys(list(current.get("article_no_displays", [])) + article_no_displays)
                     )
-                    current["relation_types"] = list(
-                        dict.fromkeys(list(current.get("relation_types", [])) + [relation_type])
+                    extra_relation_types = [relation_type]
+                    if target_law_name == source["law_name"]:
+                        extra_relation_types.append("same_law_reference")
+                    if any(
+                        str(reference.get("reference_type") or "").strip() in {"previous_article", "next_article", "current_article", "relative_scope"}
+                        for reference in target_refs
+                    ):
+                        extra_relation_types.append("relative_reference")
+                    if relation_status == "unresolved_external":
+                        extra_relation_types.append("external_reference")
+                    current["relation_types"] = list(dict.fromkeys(list(current.get("relation_types", [])) + extra_relation_types))
+                    current["related_law_names"] = list(
+                        dict.fromkeys(
+                            list(current.get("related_law_names", []))
+                            + [
+                                candidate
+                                for reference in target_refs
+                                for candidate in list(reference.get("related_law_names") or [])
+                                if str(candidate).strip()
+                            ]
+                        )
+                    )
+                    current["reference_texts"] = list(
+                        dict.fromkeys(
+                            list(current.get("reference_texts", []))
+                            + [
+                                str(reference.get("reference_text") or "").strip()
+                                for reference in target_refs
+                                if str(reference.get("reference_text") or "").strip()
+                            ]
+                        )
+                    )
+                    current["target_article_resolution_count"] = len(current.get("article_keys", []))
+                    current["resolution_status"] = _relation_resolution_status(
+                        [current.get("resolution_status")] + [str(reference.get("resolution_status") or "") for reference in target_refs]
                     )
                     if len(str(current.get("display_text") or "")) < len(_truncate_text(body_text)):
                         current["display_text"] = _truncate_text(body_text)

--- a/apps/backend/legal-pipeline/src/export/law_to_law_relation_builder.py
+++ b/apps/backend/legal-pipeline/src/export/law_to_law_relation_builder.py
@@ -40,6 +40,35 @@ def _article_text(article: dict[str, Any]) -> str:
     return "\n".join(part for part in parts if part).strip()
 
 
+def _article_reference_text(article: dict[str, Any]) -> str:
+    parts: list[str] = []
+
+    article_text = str(article.get("article_text_raw") or article.get("article_text") or "").strip()
+    if article_text:
+        parts.append(article_text)
+
+    for paragraph in article.get("paragraphs", []) if isinstance(article.get("paragraphs"), list) else []:
+        if not isinstance(paragraph, dict):
+            continue
+        paragraph_text = str(paragraph.get("paragraph_text_raw") or paragraph.get("paragraph_text") or "").strip()
+        if paragraph_text:
+            parts.append(paragraph_text)
+        for item in paragraph.get("items", []) if isinstance(paragraph.get("items"), list) else []:
+            if not isinstance(item, dict):
+                continue
+            item_text = str(item.get("item_text_raw") or item.get("item_text") or "").strip()
+            if item_text:
+                parts.append(item_text)
+            for subitem in item.get("subitems", []) if isinstance(item.get("subitems"), list) else []:
+                if not isinstance(subitem, dict):
+                    continue
+                subitem_text = str(subitem.get("subitem_text_raw") or subitem.get("subitem_text") or "").strip()
+                if subitem_text:
+                    parts.append(subitem_text)
+
+    return "\n".join(part for part in parts if part).strip()
+
+
 def _relation_text(row: dict[str, Any]) -> str:
     lines = [
         f"관계 모델: {row.get('relation_model') or ''}",
@@ -154,11 +183,12 @@ def build_law_to_law_relation_records(
                     or ""
                 ).strip()
                 body_text = _article_text(article)
-                if not body_text:
+                reference_text = _article_reference_text(article)
+                if not reference_text:
                     continue
 
                 parsed_refs = parse_law_article_references(
-                    body_text,
+                    reference_text,
                     source_law_name=source["law_name"],
                     source_law_level=payload.get("classified_level") or payload.get("kind_name"),
                     source_article_key=article_key or None,
@@ -175,10 +205,10 @@ def build_law_to_law_relation_records(
                 )
                 matched_law_names = [
                     law_name
-                    for law_name in find_related_law_names(body_text, family_law_names)
+                    for law_name in find_related_law_names(reference_text, family_law_names)
                     if law_name and law_name != source["law_name"]
                 ]
-                article_refs_map = extract_explicit_article_refs(body_text, family_law_names)
+                article_refs_map = extract_explicit_article_refs(reference_text, family_law_names)
 
                 refs_by_target: dict[str, list[dict[str, Any]]] = defaultdict(list)
                 for reference in parsed_refs:

--- a/apps/backend/legal-pipeline/src/parser/law_reference_parser.py
+++ b/apps/backend/legal-pipeline/src/parser/law_reference_parser.py
@@ -9,16 +9,25 @@ ARTICLE_PATTERN = re.compile(r"제\s*(\d+)\s*조(?:\s*의\s*(\d+))?")
 ARTICLE_RANGE_PATTERN = re.compile(
     r"제\s*(\d+)\s*조(?:\s*의\s*(\d+))?\s*(?:부터|내지)\s*제\s*(\d+)\s*조(?:\s*의\s*(\d+))?\s*(?:까지)?"
 )
+ARTICLE_BLOCK_PATTERN = (
+    r"제\s*\d+\s*조(?:\s*의\s*\d+)?"
+    r"(?:\s*(?:부터|내지)\s*제\s*\d+\s*조(?:\s*의\s*\d+)?\s*(?:까지)?)?"
+    r"(?:\s*(?:,|및|와|과|또는|혹은|·)\s*제\s*\d+\s*조(?:\s*의\s*\d+)?)*"
+)
+SINGLE_ARTICLE_BLOCK_PATTERN = (
+    r"제\s*\d+\s*조(?:\s*의\s*\d+)?"
+    r"(?:\s*(?:부터|내지)\s*제\s*\d+\s*조(?:\s*의\s*\d+)?\s*(?:까지)?)?"
+)
+LAW_NAME_TOKEN_PATTERN = r"(?!및\b|또는\b|혹은\b|와\b|과\b|전조\b|동조\b|같은\b|이\b)[가-힣0-9·ㆍ()]+"
 EXPLICIT_LAW_WITH_ARTICLE_PATTERN = re.compile(
-    r"(?P<law_name>[가-힣][가-힣0-9·ㆍ() ]{0,80}?(?:법|영|규칙|조례|규정|훈령|예규|고시))\s*"
-    r"(?P<article_block>제\s*\d+\s*조(?:\s*의\s*\d+)?(?:\s*(?:부터|내지)\s*제\s*\d+\s*조(?:\s*의\s*\d+)?\s*(?:까지)?)?(?:\s*(?:,|및|와|과|또는|혹은|·)\s*제\s*\d+\s*조(?:\s*의\s*\d+)?)*)"
+    rf"(?<![가-힣0-9])(?P<law_name>{LAW_NAME_TOKEN_PATTERN}(?:\s+{LAW_NAME_TOKEN_PATTERN}){{0,7}})\s*(?P<article_block>{ARTICLE_BLOCK_PATTERN})"
 )
 RELATIVE_SCOPE_WITH_ARTICLE_PATTERN = re.compile(
     r"(?P<prefix>이|같은)\s*(?P<scope>법|영|규칙|조례)\s*"
-    r"(?P<article_block>제\s*\d+\s*조(?:\s*의\s*\d+)?(?:\s*(?:부터|내지)\s*제\s*\d+\s*조(?:\s*의\s*\d+)?\s*(?:까지)?)?(?:\s*(?:,|및|와|과|또는|혹은|·)\s*제\s*\d+\s*조(?:\s*의\s*\d+)?)*)"
+    rf"(?P<article_block>{SINGLE_ARTICLE_BLOCK_PATTERN})"
 )
 BARE_ARTICLE_BLOCK_PATTERN = re.compile(
-    r"(?<![가-힣0-9])(?P<article_block>제\s*\d+\s*조(?:\s*의\s*\d+)?(?:\s*(?:부터|내지)\s*제\s*\d+\s*조(?:\s*의\s*\d+)?\s*(?:까지)?)?(?:\s*(?:,|및|와|과|또는|혹은|·)\s*제\s*\d+\s*조(?:\s*의\s*\d+)?)*)"
+    rf"(?<![가-힣0-9])(?P<article_block>{ARTICLE_BLOCK_PATTERN})"
 )
 RELATIVE_ARTICLE_PATTERNS = {
     "previous_article": re.compile(r"전\s*조"),
@@ -33,6 +42,15 @@ def _normalize_space(text: str) -> str:
 
 def _normalize_name(text: str) -> str:
     return re.sub(r"\s+", "", str(text or "")).strip()
+
+
+def _looks_like_law_name(text: str) -> bool:
+    candidate = _normalize_space(text)
+    if not candidate:
+        return False
+    if candidate in {"이 법", "같은 법", "이 영", "같은 영", "이 규칙", "같은 규칙", "이 조례", "같은 조례"}:
+        return False
+    return candidate.endswith(("법", "법률", "시행령", "대통령령", "령", "시행규칙", "규칙", "부령", "조례", "규정", "훈령", "예규", "고시"))
 
 
 def _article_ref(main_no: str, branch_no: str | None) -> dict[str, str]:
@@ -301,7 +319,7 @@ def parse_law_article_references(
     for match in EXPLICIT_LAW_WITH_ARTICLE_PATTERN.finditer(raw_text):
         candidate_law_name = _normalize_space(match.group("law_name"))
         article_refs = extract_article_refs(match.group("article_block"))
-        if not candidate_law_name or not article_refs:
+        if not candidate_law_name or not article_refs or not _looks_like_law_name(candidate_law_name):
             continue
         candidates, resolution_status = _resolve_law_name_candidates(
             candidate_law_name,

--- a/apps/backend/legal-pipeline/src/parser/law_reference_parser.py
+++ b/apps/backend/legal-pipeline/src/parser/law_reference_parser.py
@@ -1,0 +1,365 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from src.common.law_meta import normalize_classified_level
+
+ARTICLE_PATTERN = re.compile(r"제\s*(\d+)\s*조(?:\s*의\s*(\d+))?")
+ARTICLE_RANGE_PATTERN = re.compile(
+    r"제\s*(\d+)\s*조(?:\s*의\s*(\d+))?\s*(?:부터|내지)\s*제\s*(\d+)\s*조(?:\s*의\s*(\d+))?\s*(?:까지)?"
+)
+EXPLICIT_LAW_WITH_ARTICLE_PATTERN = re.compile(
+    r"(?P<law_name>[가-힣][가-힣0-9·ㆍ() ]{0,80}?(?:법|영|규칙|조례|규정|훈령|예규|고시))\s*"
+    r"(?P<article_block>제\s*\d+\s*조(?:\s*의\s*\d+)?(?:\s*(?:부터|내지)\s*제\s*\d+\s*조(?:\s*의\s*\d+)?\s*(?:까지)?)?(?:\s*(?:,|및|와|과|또는|혹은|·)\s*제\s*\d+\s*조(?:\s*의\s*\d+)?)*)"
+)
+RELATIVE_SCOPE_WITH_ARTICLE_PATTERN = re.compile(
+    r"(?P<prefix>이|같은)\s*(?P<scope>법|영|규칙|조례)\s*"
+    r"(?P<article_block>제\s*\d+\s*조(?:\s*의\s*\d+)?(?:\s*(?:부터|내지)\s*제\s*\d+\s*조(?:\s*의\s*\d+)?\s*(?:까지)?)?(?:\s*(?:,|및|와|과|또는|혹은|·)\s*제\s*\d+\s*조(?:\s*의\s*\d+)?)*)"
+)
+BARE_ARTICLE_BLOCK_PATTERN = re.compile(
+    r"(?<![가-힣0-9])(?P<article_block>제\s*\d+\s*조(?:\s*의\s*\d+)?(?:\s*(?:부터|내지)\s*제\s*\d+\s*조(?:\s*의\s*\d+)?\s*(?:까지)?)?(?:\s*(?:,|및|와|과|또는|혹은|·)\s*제\s*\d+\s*조(?:\s*의\s*\d+)?)*)"
+)
+RELATIVE_ARTICLE_PATTERNS = {
+    "previous_article": re.compile(r"전\s*조"),
+    "next_article": re.compile(r"다음\s*조"),
+    "current_article": re.compile(r"같은\s*조|동\s*조"),
+}
+
+
+def _normalize_space(text: str) -> str:
+    return " ".join(str(text or "").split()).strip()
+
+
+def _normalize_name(text: str) -> str:
+    return re.sub(r"\s+", "", str(text or "")).strip()
+
+
+def _article_ref(main_no: str, branch_no: str | None) -> dict[str, str]:
+    article_key = str(int(main_no)) if not branch_no else f"{int(main_no)}-{int(branch_no)}"
+    article_no_display = f"제{int(main_no)}조" if not branch_no else f"제{int(main_no)}조의{int(branch_no)}"
+    return {
+        "article_key": article_key,
+        "article_no_display": article_no_display,
+    }
+
+
+def _expand_article_range(start: tuple[str, str | None], end: tuple[str, str | None]) -> list[dict[str, str]]:
+    start_main, start_branch = start
+    end_main, end_branch = end
+    if start_branch is None and end_branch is None:
+        start_no = int(start_main)
+        end_no = int(end_main)
+        if start_no <= end_no:
+            return [_article_ref(str(article_no), None) for article_no in range(start_no, end_no + 1)]
+    if start_main == end_main and start_branch is not None and end_branch is not None:
+        start_no = int(start_branch)
+        end_no = int(end_branch)
+        if start_no <= end_no:
+            return [_article_ref(start_main, str(branch_no)) for branch_no in range(start_no, end_no + 1)]
+    return [_article_ref(start_main, start_branch), _article_ref(end_main, end_branch)]
+
+
+def extract_article_refs(article_block: str) -> list[dict[str, str]]:
+    refs: list[dict[str, str]] = []
+    seen: set[str] = set()
+
+    for match in ARTICLE_RANGE_PATTERN.finditer(article_block):
+        for article in _expand_article_range(match.group(1, 2), match.group(3, 4)):
+            if article["article_key"] in seen:
+                continue
+            seen.add(article["article_key"])
+            refs.append(article)
+
+    for match in ARTICLE_PATTERN.finditer(article_block):
+        article = _article_ref(match.group(1), match.group(2))
+        if article["article_key"] in seen:
+            continue
+        seen.add(article["article_key"])
+        refs.append(article)
+
+    return refs
+
+
+def _mask_span(text: str, start: int, end: int) -> str:
+    return text[:start] + (" " * max(0, end - start)) + text[end:]
+
+
+def _article_order_index(article_order: list[dict[str, str]]) -> dict[str, int]:
+    return {
+        str(item.get("article_key") or "").strip(): index
+        for index, item in enumerate(article_order)
+        if str(item.get("article_key") or "").strip()
+    }
+
+
+def _resolve_relative_article(
+    relation_kind: str,
+    *,
+    source_article_key: str | None,
+    article_order: list[dict[str, str]],
+) -> list[dict[str, str]]:
+    if not source_article_key:
+        return []
+
+    index_by_key = _article_order_index(article_order)
+    current_index = index_by_key.get(str(source_article_key).strip())
+    if current_index is None:
+        return []
+
+    target_index = current_index
+    if relation_kind == "previous_article":
+        target_index = current_index - 1
+    elif relation_kind == "next_article":
+        target_index = current_index + 1
+
+    if target_index < 0 or target_index >= len(article_order):
+        return []
+
+    target = article_order[target_index]
+    article_key = str(target.get("article_key") or "").strip()
+    article_no_display = str(target.get("article_no_display") or "").strip()
+    if not article_key:
+        return []
+
+    return [{"article_key": article_key, "article_no_display": article_no_display or article_key}]
+
+
+def _build_family_alias_map(
+    *,
+    root_law_name: str,
+    family_laws: list[dict[str, Any]],
+) -> dict[str, list[str]]:
+    alias_map: dict[str, list[str]] = {}
+
+    def add_alias(alias: str, law_name: str) -> None:
+        key = _normalize_name(alias)
+        value = str(law_name or "").strip()
+        if not key or not value:
+            return
+        alias_map.setdefault(key, [])
+        if value not in alias_map[key]:
+            alias_map[key].append(value)
+
+    for law in family_laws:
+        law_name = str(law.get("law_name") or "").strip()
+        if not law_name:
+            continue
+
+        add_alias(law_name, law_name)
+        suffix = law_name
+        if root_law_name and law_name.startswith(root_law_name):
+            suffix = law_name[len(root_law_name):].strip()
+        if suffix and suffix != law_name:
+            add_alias(suffix, law_name)
+
+        level = normalize_classified_level(law.get("kind_name"), law.get("classified_level"))
+        if level in {"법", "시행령", "시행규칙"}:
+            add_alias(level, law_name)
+
+    return alias_map
+
+
+def _resolve_scope_target_law_names(
+    *,
+    scope: str,
+    source_law_name: str,
+    source_law_level: str | None,
+    root_law_name: str,
+    family_laws: list[dict[str, Any]],
+) -> list[str]:
+    desired_level = {
+        "법": "법",
+        "영": "시행령",
+        "규칙": "시행규칙",
+        "조례": "조례",
+    }.get(scope, scope)
+
+    source_level = normalize_classified_level(None, source_law_level)
+    if source_level == desired_level and source_law_name:
+        return [source_law_name]
+
+    resolved: list[str] = []
+    for law in family_laws:
+        law_name = str(law.get("law_name") or "").strip()
+        if not law_name:
+            continue
+        level = normalize_classified_level(law.get("kind_name"), law.get("classified_level"))
+        if level != desired_level:
+            continue
+        if desired_level == "법" and root_law_name and law_name == root_law_name:
+            return [law_name]
+        if law_name not in resolved:
+            resolved.append(law_name)
+    return resolved
+
+
+def _resolve_law_name_candidates(
+    candidate_law_name: str,
+    *,
+    root_law_name: str,
+    source_law_name: str,
+    source_law_level: str | None,
+    family_laws: list[dict[str, Any]],
+) -> tuple[list[str], str]:
+    normalized = _normalize_name(candidate_law_name)
+    alias_map = _build_family_alias_map(root_law_name=root_law_name, family_laws=family_laws)
+    candidates = alias_map.get(normalized, [])
+    if not candidates:
+        return [], "unresolved_external"
+    if len(candidates) == 1:
+        return candidates, "resolved"
+    scope_candidates = _resolve_scope_target_law_names(
+        scope=normalized,
+        source_law_name=source_law_name,
+        source_law_level=source_law_level,
+        root_law_name=root_law_name,
+        family_laws=family_laws,
+    )
+    if len(scope_candidates) == 1:
+        return scope_candidates, "resolved"
+    return candidates, "ambiguous"
+
+
+def _append_reference(
+    results: list[dict[str, Any]],
+    seen: set[tuple[str, str, str]],
+    *,
+    reference_type: str,
+    reference_text: str,
+    target_law_name: str | None,
+    related_law_names: list[str] | None,
+    article_refs: list[dict[str, str]],
+    resolution_status: str,
+    resolution_confidence: float,
+) -> None:
+    article_keys = [item["article_key"] for item in article_refs]
+    article_no_displays = [item["article_no_display"] for item in article_refs]
+    dedup_key = (
+        reference_type,
+        str(target_law_name or "").strip(),
+        "|".join(article_keys) or _normalize_space(reference_text),
+    )
+    if dedup_key in seen:
+        return
+    seen.add(dedup_key)
+    results.append(
+        {
+            "reference_type": reference_type,
+            "reference_text": _normalize_space(reference_text),
+            "target_law_name": str(target_law_name or "").strip() or None,
+            "related_law_names": list(dict.fromkeys([name for name in related_law_names or [] if str(name).strip()])),
+            "target_article_keys": article_keys,
+            "target_article_no_displays": article_no_displays,
+            "resolution_status": resolution_status,
+            "resolution_confidence": resolution_confidence,
+        }
+    )
+
+
+def parse_law_article_references(
+    text: str,
+    *,
+    source_law_name: str,
+    source_law_level: str | None,
+    source_article_key: str | None,
+    article_order: list[dict[str, str]],
+    root_law_name: str,
+    family_laws: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    raw_text = str(text or "")
+    masked_text = raw_text
+    results: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str]] = set()
+
+    for match in RELATIVE_SCOPE_WITH_ARTICLE_PATTERN.finditer(raw_text):
+        article_refs = extract_article_refs(match.group("article_block"))
+        if not article_refs:
+            continue
+        candidates = _resolve_scope_target_law_names(
+            scope=match.group("scope"),
+            source_law_name=source_law_name,
+            source_law_level=source_law_level,
+            root_law_name=root_law_name,
+            family_laws=family_laws,
+        )
+        resolution_status = "resolved" if len(candidates) == 1 else "ambiguous"
+        target_law_name = candidates[0] if len(candidates) == 1 else None
+        _append_reference(
+            results,
+            seen,
+            reference_type="relative_scope",
+            reference_text=match.group(0),
+            target_law_name=target_law_name,
+            related_law_names=candidates,
+            article_refs=article_refs,
+            resolution_status=resolution_status,
+            resolution_confidence=0.9 if resolution_status == "resolved" else 0.6,
+        )
+        masked_text = _mask_span(masked_text, match.start(), match.end())
+
+    for match in EXPLICIT_LAW_WITH_ARTICLE_PATTERN.finditer(raw_text):
+        candidate_law_name = _normalize_space(match.group("law_name"))
+        article_refs = extract_article_refs(match.group("article_block"))
+        if not candidate_law_name or not article_refs:
+            continue
+        candidates, resolution_status = _resolve_law_name_candidates(
+            candidate_law_name,
+            root_law_name=root_law_name,
+            source_law_name=source_law_name,
+            source_law_level=source_law_level,
+            family_laws=family_laws,
+        )
+        target_law_name = candidates[0] if resolution_status == "resolved" and len(candidates) == 1 else candidate_law_name
+        _append_reference(
+            results,
+            seen,
+            reference_type="explicit_law_article",
+            reference_text=match.group(0),
+            target_law_name=target_law_name,
+            related_law_names=candidates if resolution_status != "unresolved_external" else [candidate_law_name],
+            article_refs=article_refs,
+            resolution_status=resolution_status,
+            resolution_confidence=0.95 if resolution_status == "resolved" else 0.45,
+        )
+        masked_text = _mask_span(masked_text, match.start(), match.end())
+
+    for reference_type, pattern in RELATIVE_ARTICLE_PATTERNS.items():
+        for match in pattern.finditer(masked_text):
+            article_refs = _resolve_relative_article(
+                reference_type,
+                source_article_key=source_article_key,
+                article_order=article_order,
+            )
+            if not article_refs:
+                continue
+            _append_reference(
+                results,
+                seen,
+                reference_type=reference_type,
+                reference_text=match.group(0),
+                target_law_name=source_law_name,
+                related_law_names=[source_law_name],
+                article_refs=article_refs,
+                resolution_status="resolved",
+                resolution_confidence=0.92,
+            )
+            masked_text = _mask_span(masked_text, match.start(), match.end())
+
+    for match in BARE_ARTICLE_BLOCK_PATTERN.finditer(masked_text):
+        article_refs = extract_article_refs(match.group("article_block"))
+        if not article_refs:
+            continue
+        _append_reference(
+            results,
+            seen,
+            reference_type="same_law_article",
+            reference_text=match.group("article_block"),
+            target_law_name=source_law_name,
+            related_law_names=[source_law_name],
+            article_refs=article_refs,
+            resolution_status="resolved",
+            resolution_confidence=0.9,
+        )
+
+    return results

--- a/apps/backend/legal-pipeline/tests/test_law_reference_parser.py
+++ b/apps/backend/legal-pipeline/tests/test_law_reference_parser.py
@@ -1,0 +1,69 @@
+from src.parser.law_reference_parser import parse_law_article_references
+
+
+FAMILY_LAWS = [
+    {"law_name": "근로기준법", "classified_level": "법", "kind_name": "법률"},
+    {"law_name": "근로기준법 시행령", "classified_level": "시행령", "kind_name": "대통령령"},
+    {"law_name": "근로기준법 시행규칙", "classified_level": "시행규칙", "kind_name": "고용노동부령"},
+]
+
+ARTICLE_ORDER = [
+    {"article_key": "2", "article_no_display": "제2조"},
+    {"article_key": "3", "article_no_display": "제3조"},
+    {"article_key": "4", "article_no_display": "제4조"},
+    {"article_key": "5", "article_no_display": "제5조"},
+]
+
+
+def test_parse_law_article_references_resolves_same_law_and_relative_refs():
+    refs = parse_law_article_references(
+        "전조 및 제5조에 따른다.",
+        source_law_name="근로기준법",
+        source_law_level="법",
+        source_article_key="4",
+        article_order=ARTICLE_ORDER,
+        root_law_name="근로기준법",
+        family_laws=FAMILY_LAWS,
+    )
+
+    by_type = {ref["reference_type"]: ref for ref in refs}
+    assert by_type["previous_article"]["target_law_name"] == "근로기준법"
+    assert by_type["previous_article"]["target_article_keys"] == ["3"]
+    assert by_type["same_law_article"]["target_article_keys"] == ["5"]
+
+
+def test_parse_law_article_references_resolves_relative_scope_and_ranges():
+    refs = parse_law_article_references(
+        "이 영 제11조 및 제3조부터 제5조까지를 따른다.",
+        source_law_name="근로기준법 시행규칙",
+        source_law_level="시행규칙",
+        source_article_key="4",
+        article_order=ARTICLE_ORDER,
+        root_law_name="근로기준법",
+        family_laws=FAMILY_LAWS,
+    )
+
+    relative_scope = next(ref for ref in refs if ref["reference_type"] == "relative_scope")
+    same_law = next(ref for ref in refs if ref["reference_type"] == "same_law_article")
+
+    assert relative_scope["target_law_name"] == "근로기준법 시행령"
+    assert relative_scope["target_article_keys"] == ["11"]
+    assert same_law["target_article_keys"] == ["3", "4", "5"]
+
+
+def test_parse_law_article_references_marks_external_law_refs_unresolved():
+    refs = parse_law_article_references(
+        "민법 제750조에 따른 손해배상을 청구한다.",
+        source_law_name="근로기준법",
+        source_law_level="법",
+        source_article_key="4",
+        article_order=ARTICLE_ORDER,
+        root_law_name="근로기준법",
+        family_laws=FAMILY_LAWS,
+    )
+
+    assert len(refs) == 1
+    ref = refs[0]
+    assert ref["target_law_name"] == "민법"
+    assert ref["target_article_keys"] == ["750"]
+    assert ref["resolution_status"] == "unresolved_external"

--- a/apps/backend/legal-pipeline/tests/test_law_to_law_relation_builder.py
+++ b/apps/backend/legal-pipeline/tests/test_law_to_law_relation_builder.py
@@ -66,3 +66,58 @@ def test_build_law_to_law_relation_records_extracts_explicit_law_and_article_ref
     assert decree_row["relation_model"] == "law_to_law"
     assert decree_row["article_keys"] == ["11"]
     assert decree_row["article_no_displays"] == ["제11조"]
+
+
+def test_build_law_to_law_relation_records_extracts_same_law_and_external_refs(tmp_path):
+    normalized_dir = tmp_path / "normalized" / "01_current_law" / "근로기준법"
+
+    _write_json(
+        normalized_dir / "근로기준법__parsed_law.json",
+        {
+            "law_name": "근로기준법",
+            "law_id": "001872",
+            "mst": "269390",
+            "ef_yd": "20250223",
+            "kind_name": "법률",
+            "classified_level": "법",
+            "articles": [
+                {
+                    "article_key": "3",
+                    "article_no": "제3조",
+                    "article_no_display": "제3조",
+                    "article_title": "정의",
+                    "article_title_raw": "정의",
+                    "article_text": "정의를 정한다.",
+                    "article_text_raw": "정의를 정한다.",
+                },
+                {
+                    "article_key": "4",
+                    "article_no": "제4조",
+                    "article_no_display": "제4조",
+                    "article_title": "근로조건",
+                    "article_title_raw": "근로조건",
+                    "article_text": "전조 및 민법 제750조를 따른다.",
+                    "article_text_raw": "전조 및 민법 제750조를 따른다.",
+                },
+            ],
+        },
+    )
+
+    rows = build_law_to_law_relation_records(tmp_path / "normalized" / "01_current_law")
+    rows_by_target = {row["law_name"]: row for row in rows}
+
+    same_law_row = rows_by_target["근로기준법"]
+    assert same_law_row["source_law_uid"] == same_law_row["law_uid"]
+    assert "same_law_reference" in same_law_row["relation_types"]
+    assert "relative_reference" in same_law_row["relation_types"]
+    assert same_law_row["article_keys"] == ["3"]
+    assert same_law_row["source_article_key"] == "4"
+    assert same_law_row["resolution_status"] == "resolved"
+    assert same_law_row["reference_texts"] == ["전조"]
+
+    external_row = rows_by_target["민법"]
+    assert external_row["law_uid"] is None
+    assert external_row["relation_type"] == "related_law"
+    assert "external_reference" in external_row["relation_types"]
+    assert external_row["article_keys"] == ["750"]
+    assert external_row["resolution_status"] == "unresolved_external"


### PR DESCRIPTION
## Work Description
- 법령 본문의 조문 단위 참조 추출 강화해 관계 생성 품질 개선
- 기존 law_to_law 스키마 유지하면서, 같은 법령/같은 법률군 내 참조
- 외부 법령명 + 조문 미해결 참조(본문 내용X, 법령명, 조 만 추출)

## Changes
### 핵심 변경
- 법령 본문 조문 참조 추출 파서 추가
- 법령 간 관계 필버를 새 참조 파서 기반을 전환
- law_to_law relation 필드 보강
- 같은 조문, 전조/다음조, 같은 조/동조,이 법/ 같은 법/이 영/ 이 규칙 기반으로 상대 참조
- 동일 법령 내 관계, root 법률군 내 관계 생성
- 외부 법령명 + 조문 참조 관계만 보존

### 제외 법위
-  조 / 항 / 호 / 목 하위 단위 (edge) 확장 1차 범위 에서 제외
- 새 relation 모델 추가 없이 기존 law_to_law 포맷 유지

## 동작 범위
- 작업 범위 `app/backend/leagal-pipeline`
- 루트 gitignore 제외 파일 추가
- 기본 OpenSearch/Qdrant 유지

## Testing
- [x] 로컬 uv run pytest tests 통과 

## Related Issue
close #24 
