### PR TITLE
[Feature] OpenAI 임베딩 provider 분기 및 Retrieval 설정 연동

### DIFF
--- a/apps/backend/api/.env.example
+++ b/apps/backend/api/.env.example
@@ -8,8 +8,10 @@ QDRANT_VECTOR_NAME_MAP=law_article=body
 OPENSEARCH_URL=http://localhost:9200
 OPENSEARCH_INDEX=las_legal_docs
 
-# Embedding model (768 dim)
-EMBEDDING_MODEL=sentence-transformers/paraphrase-multilingual-mpnet-base-v2
+# Query embedding model (1024차원)
+EMBEDDING_MODEL=text-embedding-3-large
+EMBEDDING_PROVIDER=openai
+OPENAI_API_KEY=
 
 # LLM
 LLM_PROVIDER=gemini

--- a/apps/backend/api/.env.example
+++ b/apps/backend/api/.env.example
@@ -8,10 +8,14 @@ QDRANT_VECTOR_NAME_MAP=law_article=body
 OPENSEARCH_URL=http://localhost:9200
 OPENSEARCH_INDEX=las_legal_docs
 
-# Query embedding model (1024차원)
-EMBEDDING_MODEL=text-embedding-3-large
-EMBEDDING_PROVIDER=openai
-OPENAI_API_KEY=
+# Embedding provider (sentence_transformers | openai)
+EMBEDDING_PROVIDER=sentence_transformers
+EMBEDDING_MODEL=sentence-transformers/paraphrase-multilingual-mpnet-base-v2
+# OpenAI 사용 시
+# EMBEDDING_PROVIDER=openai
+# EMBEDDING_MODEL=text-embedding-3-large
+# OPENAI_API_KEY=
+# OPENAI_EMBEDDING_DIMENSIONS=1024
 
 # LLM
 LLM_PROVIDER=gemini

--- a/apps/backend/api/README.md
+++ b/apps/backend/api/README.md
@@ -34,8 +34,10 @@ QDRANT_COLLECTIONS=law_article,legal_case,legal_relation
 OPENSEARCH_URL=http://localhost:9200
 OPENSEARCH_INDEX=las_legal_docs
 
-# 임베딩 모델 (768차원)
+# 임베딩 provider (sentence_transformers | openai)
+EMBEDDING_PROVIDER=sentence_transformers
 EMBEDDING_MODEL=sentence-transformers/paraphrase-multilingual-mpnet-base-v2
+# OpenAI 사용 시: EMBEDDING_PROVIDER=openai, EMBEDDING_MODEL=text-embedding-3-large, OPENAI_API_KEY=...
 
 # LLM — Gemini
 LLM_PROVIDER=gemini

--- a/apps/backend/api/README.md
+++ b/apps/backend/api/README.md
@@ -14,7 +14,7 @@ Legal AI Assistant FastAPI 백엔드 서버.
 
 ```bash
 cd apps/backend/api
-cp ../rag/.env.example .env   # 최초 1회 — QDRANT_URL, GEMINI_API_KEY 등 채워야 함
+ln -sf ../rag/.env .env   # rag/.env를 공유 (최초 1회)
 
 uv run uvicorn main:app --reload                    # 개발 서버
 uv run uvicorn main:app --host 0.0.0.0 --port 8000  # 운영 서버

--- a/apps/backend/api/README.md
+++ b/apps/backend/api/README.md
@@ -14,7 +14,7 @@ Legal AI Assistant FastAPI 백엔드 서버.
 
 ```bash
 cd apps/backend/api
-ln -sf ../rag/.env .env   # rag/.env를 공유 (최초 1회)
+ln -sf ../rag/.env .env   # rag/.env를 공유 (최초 1회, rag/.env가 먼저 설정되어 있어야 함)
 
 uv run uvicorn main:app --reload                    # 개발 서버
 uv run uvicorn main:app --host 0.0.0.0 --port 8000  # 운영 서버

--- a/apps/backend/rag/.env.example
+++ b/apps/backend/rag/.env.example
@@ -10,8 +10,17 @@ OPENSEARCH_INDEX=law_article,legal_case,legal_relation
 # OPENSEARCH_USERNAME=
 # OPENSEARCH_PASSWORD=
 
-# Query embedding model (768 dim)
+# Embedding provider (sentence_transformers | openai)
+EMBEDDING_PROVIDER=sentence_transformers
+
+# sentence_transformers 사용 시 (기본값, 768 dim)
 EMBEDDING_MODEL=sentence-transformers/paraphrase-multilingual-mpnet-base-v2
+
+# OpenAI 사용 시 (1024 dim)
+# EMBEDDING_PROVIDER=openai
+# EMBEDDING_MODEL=text-embedding-3-large
+# OPENAI_API_KEY=
+# OPENAI_BASE_URL=https://api.openai.com/v1
 
 # Index input glob (for index_embedded_jsonl.py)
 INDEX_INPUT_GLOB=data/dropbox/*.embedded.jsonl

--- a/apps/backend/rag/.env.example
+++ b/apps/backend/rag/.env.example
@@ -22,9 +22,6 @@ EMBEDDING_MODEL=sentence-transformers/paraphrase-multilingual-mpnet-base-v2
 # OPENAI_API_KEY=
 # OPENAI_BASE_URL=https://api.openai.com/v1
 
-# Index input glob (for index_embedded_jsonl.py)
-INDEX_INPUT_GLOB=data/dropbox/*.embedded.jsonl
-
 # LLM provider (openai_compat | gemini)
 LLM_PROVIDER=gemini
 

--- a/apps/backend/rag/README.md
+++ b/apps/backend/rag/README.md
@@ -107,6 +107,24 @@ uv run python cli/generate_answer.py --question "연장근로 최대 시간은?"
 - `source_id_normalized`: 중복 제거/병합 기준으로 사용한 정규화 source id
 - 운영/표시 권장: `source_id`(= normalized 우선), 디버깅 시 raw 함께 확인
 
+## 임베딩 환경변수
+
+`EMBEDDING_PROVIDER`로 임베딩 backend를 전환할 수 있다.
+
+```env
+# sentence-transformers 사용 (기본값, 로컬 모델)
+EMBEDDING_PROVIDER=sentence_transformers
+EMBEDDING_MODEL=sentence-transformers/paraphrase-multilingual-mpnet-base-v2
+
+# OpenAI 사용 시
+# EMBEDDING_PROVIDER=openai
+# EMBEDDING_MODEL=text-embedding-3-large
+# OPENAI_API_KEY=...
+# OPENAI_BASE_URL=https://api.openai.com/v1  # 기본값, 생략 가능
+```
+
+> OpenAI로 전환 시 Qdrant에 저장된 벡터와 차원이 맞아야 한다 (1024 dim).
+
 ## LLM 환경변수 (generation CLI 사용 시)
 
 `generator.py` / `generate_answer.py` 실행 시 `.env`에 추가로 필요하다.

--- a/apps/backend/rag/rag_pipeline/generation/pipeline.py
+++ b/apps/backend/rag/rag_pipeline/generation/pipeline.py
@@ -132,6 +132,9 @@ class RagPipeline:
                     opensearch_username=os.getenv("OPENSEARCH_USERNAME") or None,
                     opensearch_password=os.getenv("OPENSEARCH_PASSWORD") or None,
                     embedding_model=os.getenv("EMBEDDING_MODEL", DEFAULT_EMBEDDING_MODEL),
+                    embedding_provider=os.getenv("EMBEDDING_PROVIDER", "sentence_transformers"),
+                    embedding_api_key=os.getenv("OPENAI_API_KEY") or None,
+                    embedding_api_base_url=os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1"),
                 ),
                 generation=GenerationConfig.from_env(),
             )
@@ -160,6 +163,9 @@ class RagPipeline:
                 collection=collection,
                 timeout=rcfg.timeout,
                 embedding_model=rcfg.embedding_model,
+                embedding_provider=rcfg.embedding_provider,
+                embedding_api_key=rcfg.embedding_api_key,
+                embedding_api_base_url=rcfg.embedding_api_base_url,
                 api_key=rcfg.qdrant_api_key,
                 doc_types=doc_types,
                 law_names=law_names,
@@ -249,7 +255,10 @@ class RagPipeline:
 
     def is_embedding_cold_start(self) -> bool:
         """현재 프로세스에서 임베딩 모델 첫 로드가 필요한 상태인지 반환한다."""
-        return not is_embedding_model_cached(self._cfg.retrieval.embedding_model)
+        return not is_embedding_model_cached(
+            self._cfg.retrieval.embedding_model,
+            provider=self._cfg.retrieval.embedding_provider,
+        )
 
     def run(
         self,

--- a/apps/backend/rag/rag_pipeline/generation/pipeline.py
+++ b/apps/backend/rag/rag_pipeline/generation/pipeline.py
@@ -135,6 +135,7 @@ class RagPipeline:
                     embedding_provider=os.getenv("EMBEDDING_PROVIDER", "sentence_transformers"),
                     embedding_api_key=os.getenv("OPENAI_API_KEY") or None,
                     embedding_api_base_url=os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1"),
+                    embedding_dimensions=int(d) if (d := os.getenv("OPENAI_EMBEDDING_DIMENSIONS", "").strip()) else None,
                 ),
                 generation=GenerationConfig.from_env(),
             )
@@ -166,6 +167,7 @@ class RagPipeline:
                 embedding_provider=rcfg.embedding_provider,
                 embedding_api_key=rcfg.embedding_api_key,
                 embedding_api_base_url=rcfg.embedding_api_base_url,
+                embedding_dimensions=rcfg.embedding_dimensions,
                 api_key=rcfg.qdrant_api_key,
                 doc_types=doc_types,
                 law_names=law_names,

--- a/apps/backend/rag/rag_pipeline/query_parser/parser.py
+++ b/apps/backend/rag/rag_pipeline/query_parser/parser.py
@@ -1,0 +1,209 @@
+"""Gemini Flash-Lite 기반 Query Parser.
+
+사용자 질문에서 법령명, 조문번호, intent를 추출하고 법률 무관 질문을 판별한다.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass
+
+from ..generation.llm_client import generate_answer
+from .data.few_shot import FEW_SHOT_EXAMPLES
+from .data.law_names import ALIAS_MAP, LAW_NAME_LIST
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PARSER_MODEL = "gemini-2.0-flash-lite"
+_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/models"
+
+_SYSTEM_PROMPT = """\
+당신은 법률 질문 분석기입니다.
+사용자 질문에서 아래 정보를 추출해 JSON으로만 응답하세요. 설명은 절대 추가하지 마세요.
+
+출력 형식:
+{{"law_names": [...], "article_no": "...", "intent": "...", "is_legal": true/false}}
+
+- law_names: 아래 목록 중 질문에 해당하는 법령 정식명칭 (없으면 [])
+- article_no: 조문번호 (예: "제17조", 없으면 "")
+- intent: "normative" | "case_law" | "mixed" | null (법률 무관이면 null)
+- is_legal: 법률 관련 질문이면 true, 아니면 false
+
+인식 가능한 법령 목록:
+{law_list}
+"""
+
+_VALID_INTENTS = frozenset({"normative", "case_law", "mixed"})
+_JSON_BLOCK_RE = re.compile(r"```(?:json)?\s*(\{.*?\})\s*```", re.DOTALL)
+_JSON_BARE_RE = re.compile(r"\{.*?\}", re.DOTALL)
+_ARTICLE_PREFIX_RE = re.compile(r"^\d")
+
+
+@dataclass
+class QueryParseResult:
+    """Query Parser 반환값."""
+
+    law_names: list[str]
+    article_no: str
+    intent: str | None  # "normative" | "case_law" | "mixed" | None
+    is_legal: bool
+    parser_fallback: bool = False
+
+
+@dataclass
+class QueryParserConfig:
+    """QueryParser 설정."""
+
+    api_key: str
+    model: str = DEFAULT_PARSER_MODEL
+    timeout: int = 10
+    strict_mode: bool = False
+
+    @property
+    def url(self) -> str:
+        return f"{_GEMINI_BASE_URL}/{self.model}:generateContent"
+
+    @classmethod
+    def from_env(cls) -> QueryParserConfig:
+        """환경변수에서 설정을 읽어 QueryParserConfig를 생성한다.
+
+        모델 우선순위: QUERY_PARSER_MODEL → GEMINI_MODEL → DEFAULT_PARSER_MODEL
+        """
+        model = (
+            os.getenv("QUERY_PARSER_MODEL", "").strip()
+            or os.getenv("GEMINI_MODEL", "").strip()
+            or DEFAULT_PARSER_MODEL
+        )
+        api_key = os.getenv("GEMINI_API_KEY", "").strip()
+        strict = os.getenv("QUERY_PARSER_STRICT", "").strip().lower() in ("1", "true")
+        timeout = int(os.getenv("QUERY_PARSER_TIMEOUT", "10").strip() or "10")
+        return cls(api_key=api_key, model=model, timeout=timeout, strict_mode=strict)
+
+
+# ── 프롬프트 빌더 ─────────────────────────────────────────────────────────────
+
+def _build_prompt(query: str) -> str:
+    """few-shot 예시를 포함한 사용자 메시지를 생성한다."""
+    lines: list[str] = []
+    for q, expected in FEW_SHOT_EXAMPLES:
+        lines.append(f"질문: {q}")
+        lines.append(f"출력: {expected}")
+        lines.append("")
+    lines.append(f"질문: {query}")
+    lines.append("출력:")
+    return "\n".join(lines)
+
+
+def _build_system_prompt() -> str:
+    law_list = "\n".join(f"- {name}" for name in LAW_NAME_LIST)
+    return _SYSTEM_PROMPT.format(law_list=law_list)
+
+
+# ── LLM 출력 파싱 ─────────────────────────────────────────────────────────────
+
+def _extract_json(text: str) -> dict:
+    """LLM 출력 텍스트에서 JSON 객체를 추출한다.
+
+    마크다운 코드펜스(```json ... ```)로 감싸진 경우도 처리한다.
+    """
+    m = _JSON_BLOCK_RE.search(text)
+    if m:
+        return json.loads(m.group(1))
+    m = _JSON_BARE_RE.search(text)
+    if m:
+        return json.loads(m.group(0))
+    raise ValueError(f"JSON을 찾을 수 없습니다: {text!r}")
+
+
+def _normalize_law_names(raw: object) -> list[str]:
+    """약칭을 정식명칭으로 변환하고, 사전에 없는 항목은 제거한다."""
+    if not isinstance(raw, list):
+        return []
+    valid = set(LAW_NAME_LIST)
+    result: list[str] = []
+    for item in raw:
+        if not isinstance(item, str):
+            continue
+        name = ALIAS_MAP.get(item.strip(), item.strip())
+        if name in valid and name not in result:
+            result.append(name)
+    return result
+
+
+def _normalize_article_no(raw: object) -> str:
+    """조문번호 표기를 정규화한다 (예: '17조' → '제17조')."""
+    if not isinstance(raw, str):
+        return ""
+    raw = raw.strip()
+    if raw and _ARTICLE_PREFIX_RE.match(raw):
+        raw = f"제{raw}"
+    return raw
+
+
+def _parse_llm_output(text: str) -> QueryParseResult:
+    data = _extract_json(text)
+    return QueryParseResult(
+        law_names=_normalize_law_names(data.get("law_names")),
+        article_no=_normalize_article_no(data.get("article_no")),
+        intent=data.get("intent") if data.get("intent") in _VALID_INTENTS else None,
+        is_legal=bool(data.get("is_legal", True)),
+    )
+
+
+# ── QueryParser ───────────────────────────────────────────────────────────────
+
+class QueryParser:
+    """질문을 Gemini LLM으로 파싱해 구조화 결과를 반환한다."""
+
+    def __init__(self, config: QueryParserConfig) -> None:
+        self._cfg = config
+        self._system_prompt = _build_system_prompt()
+
+    @classmethod
+    def from_env(cls) -> QueryParser:
+        """환경변수에서 설정을 읽어 인스턴스를 생성한다."""
+        return cls(QueryParserConfig.from_env())
+
+    def parse(self, query: str) -> QueryParseResult:
+        """질문을 파싱해 구조화 결과를 반환한다.
+
+        strict_mode=False(기본값): 파싱 실패 시 fallback 결과 반환 + 경고 로그.
+        strict_mode=True: 파싱 실패 시 예외 raise.
+        """
+        cfg = self._cfg
+        try:
+            raw_text = generate_answer(
+                _build_prompt(query),
+                provider="gemini",
+                url=cfg.url,
+                model=cfg.model,
+                api_key=cfg.api_key,
+                timeout=cfg.timeout,
+                max_tokens=256,
+                temperature=0.0,
+                system_prompt=self._system_prompt,
+            )
+            result = _parse_llm_output(raw_text)
+            logger.debug(
+                "query_parser: query=%r law_names=%r article_no=%r intent=%r is_legal=%r",
+                query[:80], result.law_names, result.article_no, result.intent, result.is_legal,
+            )
+            return result
+
+        except Exception as exc:
+            if cfg.strict_mode:
+                raise
+            logger.warning(
+                "query_parser fallback: parser_fallback=true query=%r error=%s",
+                query[:80], exc,
+            )
+            return QueryParseResult(
+                law_names=[],
+                article_no="",
+                intent=None,
+                is_legal=True,
+                parser_fallback=True,
+            )

--- a/apps/backend/rag/rag_pipeline/retrieval/common.py
+++ b/apps/backend/rag/rag_pipeline/retrieval/common.py
@@ -84,9 +84,12 @@ def _embed_query_openai(
     model_name: str,
     api_key: str,
     api_base_url: str,
+    dimensions: int | None = None,
 ) -> list[float]:
     """OpenAI Embeddings API를 호출해 벡터를 반환한다."""
-    payload = {"model": model_name, "input": query_text}
+    payload: dict[str, Any] = {"model": model_name, "input": query_text}
+    if dimensions:
+        payload["dimensions"] = dimensions
     headers = {
         "Content-Type": "application/json",
         "Authorization": f"Bearer {api_key}",
@@ -104,6 +107,7 @@ def embed_query(
     provider: str = "sentence_transformers",
     api_key: str | None = None,
     api_base_url: str = DEFAULT_OPENAI_API_BASE_URL,
+    dimensions: int | None = None,
 ) -> list[float]:
     """텍스트를 임베딩 벡터로 변환한다.
 
@@ -127,7 +131,7 @@ def embed_query(
     if provider == "openai":
         if not api_key:
             raise RetrievalError("OpenAI 임베딩 사용 시 api_key가 필요합니다.")
-        return _embed_query_openai(query_text, model_name, api_key, api_base_url)
+        return _embed_query_openai(query_text, model_name, api_key, api_base_url, dimensions)
 
     # sentence_transformers
     try:

--- a/apps/backend/rag/rag_pipeline/retrieval/common.py
+++ b/apps/backend/rag/rag_pipeline/retrieval/common.py
@@ -18,13 +18,20 @@ import urllib.request
 from typing import Any
 
 DEFAULT_EMBEDDING_MODEL = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
+DEFAULT_OPENAI_EMBEDDING_MODEL = "text-embedding-3-large"
+DEFAULT_OPENAI_API_BASE_URL = "https://api.openai.com/v1"
 SNIPPET_MAX_LEN = 180
 
 _MODEL_CACHE: dict[str, Any] = {}
 
 
-def is_embedding_model_cached(model_name: str) -> bool:
-    """현재 프로세스에 임베딩 모델이 메모리 캐시되어 있으면 True."""
+def is_embedding_model_cached(model_name: str, provider: str = "sentence_transformers") -> bool:
+    """현재 프로세스에 임베딩 모델이 메모리 캐시되어 있으면 True.
+
+    OpenAI provider는 로컬 모델 로드가 없으므로 항상 True를 반환한다.
+    """
+    if provider == "openai":
+        return True
     return model_name in _MODEL_CACHE
 
 
@@ -72,21 +79,41 @@ def http_json(
 
 # ── 임베딩 ────────────────────────────────────────────────────────────────────
 
-def embed_query(text: str, model_name: str) -> list[float]:
+def _embed_query_openai(
+    query_text: str,
+    model_name: str,
+    api_key: str,
+    api_base_url: str,
+) -> list[float]:
+    """OpenAI Embeddings API를 호출해 벡터를 반환한다."""
+    payload = {"model": model_name, "input": query_text}
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_key}",
+    }
+    res = http_json("POST", f"{api_base_url}/embeddings", payload, headers, timeout=30)
+    try:
+        return list(res["data"][0]["embedding"])
+    except (KeyError, IndexError, TypeError) as exc:
+        raise RetrievalError(f"OpenAI 임베딩 응답 파싱 실패: {exc}\n응답: {res}") from exc
+
+
+def embed_query(
+    text: str,
+    model_name: str,
+    provider: str = "sentence_transformers",
+    api_key: str | None = None,
+    api_base_url: str = DEFAULT_OPENAI_API_BASE_URL,
+) -> list[float]:
     """텍스트를 임베딩 벡터로 변환한다.
 
+    provider가 'openai'이면 OpenAI Embeddings API를 호출한다.
+    그 외(기본값)는 sentence-transformers 로컬 모델을 사용하며,
     모델은 _MODEL_CACHE에 캐싱되어 반복 호출 시 재로드하지 않는다.
 
     Raises:
-        RetrievalError: 패키지 미설치, 빈 텍스트, 토크나이징 실패 시.
+        RetrievalError: 패키지 미설치, 빈 텍스트, API 오류 시.
     """
-    try:
-        from sentence_transformers import SentenceTransformer
-    except Exception as exc:
-        raise RetrievalError(
-            "sentence-transformers가 필요합니다.\n설치: uv add sentence-transformers"
-        ) from exc
-
     if isinstance(text, str):
         query_text = text.strip()
     elif isinstance(text, (list, tuple)):
@@ -96,6 +123,19 @@ def embed_query(text: str, model_name: str) -> list[float]:
 
     if not query_text:
         raise RetrievalError("질문 텍스트가 비어 있습니다.")
+
+    if provider == "openai":
+        if not api_key:
+            raise RetrievalError("OpenAI 임베딩 사용 시 api_key가 필요합니다.")
+        return _embed_query_openai(query_text, model_name, api_key, api_base_url)
+
+    # sentence_transformers
+    try:
+        from sentence_transformers import SentenceTransformer
+    except Exception as exc:
+        raise RetrievalError(
+            "sentence-transformers가 필요합니다.\n설치: uv add sentence-transformers"
+        ) from exc
 
     model = _MODEL_CACHE.get(model_name)
     if model is None:

--- a/apps/backend/rag/rag_pipeline/retrieval/qdrant.py
+++ b/apps/backend/rag/rag_pipeline/retrieval/qdrant.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from .common import (
     DEFAULT_EMBEDDING_MODEL,
+    DEFAULT_OPENAI_API_BASE_URL,
     SNIPPET_MAX_LEN,
     dedup_normalized_rows,
     embed_query,
@@ -58,6 +59,9 @@ def search_qdrant(
     collection: str,
     timeout: int,
     embedding_model: str = DEFAULT_EMBEDDING_MODEL,
+    embedding_provider: str = "sentence_transformers",
+    embedding_api_key: str | None = None,
+    embedding_api_base_url: str = DEFAULT_OPENAI_API_BASE_URL,
     api_key: str | None = None,
     doc_types: list[str] | None = None,
     law_names: list[str] | None = None,
@@ -70,7 +74,13 @@ def search_qdrant(
     dedup=True일 경우 top_k * fetch_multiplier 만큼 먼저 가져온 뒤
     중복 제거 후 top_k개로 잘라낸다.
     """
-    vector = embed_query(query, embedding_model)
+    vector = embed_query(
+        query,
+        embedding_model,
+        provider=embedding_provider,
+        api_key=embedding_api_key,
+        api_base_url=embedding_api_base_url,
+    )
 
     headers = {"Content-Type": "application/json"}
     if api_key:

--- a/apps/backend/rag/rag_pipeline/retrieval/qdrant.py
+++ b/apps/backend/rag/rag_pipeline/retrieval/qdrant.py
@@ -62,6 +62,7 @@ def search_qdrant(
     embedding_provider: str = "sentence_transformers",
     embedding_api_key: str | None = None,
     embedding_api_base_url: str = DEFAULT_OPENAI_API_BASE_URL,
+    embedding_dimensions: int | None = None,
     api_key: str | None = None,
     doc_types: list[str] | None = None,
     law_names: list[str] | None = None,
@@ -80,6 +81,7 @@ def search_qdrant(
         provider=embedding_provider,
         api_key=embedding_api_key,
         api_base_url=embedding_api_base_url,
+        dimensions=embedding_dimensions,
     )
 
     headers = {"Content-Type": "application/json"}

--- a/apps/backend/rag/rag_pipeline/retrieval/service.py
+++ b/apps/backend/rag/rag_pipeline/retrieval/service.py
@@ -25,6 +25,7 @@ class RetrievalConfig:
     embedding_provider: str = "sentence_transformers"
     embedding_api_key: str | None = None
     embedding_api_base_url: str = DEFAULT_OPENAI_API_BASE_URL
+    embedding_dimensions: int | None = None
 
     # 파이프라인 파라미터
     top_k: int = 5

--- a/apps/backend/rag/rag_pipeline/retrieval/service.py
+++ b/apps/backend/rag/rag_pipeline/retrieval/service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .common import DEFAULT_EMBEDDING_MODEL
+from .common import DEFAULT_EMBEDDING_MODEL, DEFAULT_OPENAI_API_BASE_URL
 
 
 @dataclass
@@ -22,6 +22,9 @@ class RetrievalConfig:
     opensearch_username: str | None = None
     opensearch_password: str | None = None
     embedding_model: str = DEFAULT_EMBEDDING_MODEL
+    embedding_provider: str = "sentence_transformers"
+    embedding_api_key: str | None = None
+    embedding_api_base_url: str = DEFAULT_OPENAI_API_BASE_URL
 
     # 파이프라인 파라미터
     top_k: int = 5

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -19,6 +19,7 @@ EMBEDDING_DEVICE=CPU
 # EMBEDDING_PROVIDER=openai
 # EMBEDDING_MODEL=text-embedding-3-large
 # OPENAI_BASE_URL=https://api.openai.com/v1
+# OPENAI_EMBEDDING_DIMENSIONS=1024
 
 # Vector DB - if running in same Compose stack, prefer service name over localhost
 QDRANT_URL=http://qdrant:6333

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -10,9 +10,15 @@ GEMINI_API_KEY=
 GEMINI_MODEL=gemini-flash-latest
 
 # Embedding
+# provider: sentence_transformers (기본값) | openai
+EMBEDDING_PROVIDER=sentence_transformers
 EMBEDDING_MODEL=sentence-transformers/paraphrase-multilingual-mpnet-base-v2
 EMBEDDING_BACKEND=cpu
 EMBEDDING_DEVICE=CPU
+# OpenAI 임베딩 사용 시
+# EMBEDDING_PROVIDER=openai
+# EMBEDDING_MODEL=text-embedding-3-large
+# OPENAI_BASE_URL=https://api.openai.com/v1
 
 # Vector DB - if running in same Compose stack, prefer service name over localhost
 QDRANT_URL=http://qdrant:6333

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -34,6 +34,12 @@ OPENSEARCH_INDEX=las_legal_docs
 # OPENSEARCH_USERNAME=
 # OPENSEARCH_PASSWORD=
 
+# Query Parser (법령명/조문번호 추출 LLM)
+# 생략 시 GEMINI_MODEL → gemini-2.0-flash-lite 순으로 fallback
+# QUERY_PARSER_MODEL=gemini-2.0-flash-lite
+# QUERY_PARSER_TIMEOUT=10
+# QUERY_PARSER_STRICT=false
+
 # LLM provider
 LLM_PROVIDER=gemini
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -22,9 +22,15 @@ services:
       - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
       - GEMINI_MODEL=${GEMINI_MODEL:-gemini-flash-latest}
+      - EMBEDDING_PROVIDER=${EMBEDDING_PROVIDER:-sentence_transformers}
       - EMBEDDING_MODEL=${EMBEDDING_MODEL:-sentence-transformers/paraphrase-multilingual-mpnet-base-v2}
       - EMBEDDING_BACKEND=${EMBEDDING_BACKEND:-cpu}
       - EMBEDDING_DEVICE=${EMBEDDING_DEVICE:-CPU}
+      - OPENAI_BASE_URL=${OPENAI_BASE_URL:-}
+      - OPENAI_EMBEDDING_DIMENSIONS=${OPENAI_EMBEDDING_DIMENSIONS:-}
+      - QUERY_PARSER_MODEL=${QUERY_PARSER_MODEL:-}
+      - QUERY_PARSER_TIMEOUT=${QUERY_PARSER_TIMEOUT:-10}
+      - QUERY_PARSER_STRICT=${QUERY_PARSER_STRICT:-false}
       - QDRANT_URL=${QDRANT_URL:-http://qdrant:6333}
       - QDRANT_COLLECTIONS=${QDRANT_COLLECTIONS:-law_article,legal_case,legal_relation}
       - QDRANT_API_KEY=${QDRANT_API_KEY:-}


### PR DESCRIPTION
## Work Description
- Retrieval 단계에서 OpenAI 임베딩 provider를 선택적으로 사용할 수 있도록 분기 로직을 추가했습니다.
- embedding provider 설정을 RetrievalConfig 및 환경변수와 연동하여, 실행 시 provider를 유연하게 변경할 수 있도록 구조를 개선했습니다.
- OpenAI 임베딩 사용 시 벡터 차원 수를 환경변수로 제어할 수 있도록 dimensions 파라미터를 전 구간에 전달하도록 수정했습니다.

## Changes
- retrieval 단계 OpenAI 임베딩 provider 분기 추가
  - `common.py` — `embed_query()`에 OpenAI 분기 및 cold start 처리 추가
  - `qdrant.py` — `search_qdrant()`에 embedding provider 파라미터 전달

- RetrievalConfig 설정 확장 및 환경변수 연동
  - embedding provider 설정 추가
  - retrieval 단계 전체로 provider 값 전달
  - cold start 판별 로직에 provider 반영

- OpenAI 임베딩 dimensions 설정 지원
  - `embed_query`, `search_qdrant`, `RetrievalConfig`, `pipeline.py` 전 구간에 dimensions 파라미터 연결
  - `OPENAI_EMBEDDING_DIMENSIONS` 환경변수로 벡터 차원 수 제어 가능

- 환경설정 및 문서 업데이트
  - `.env.example`에 `EMBEDDING_PROVIDER`, `OPENAI_API_KEY` 추가
  - API 및 README에 설정 방법 및 symlink 안내 반영

## Testing
- [x] 로컬 테스트 완료
- [x] 기능 동작 확인

## Related Issue
close #68
