### PR TITLE
[Fix] SQLAlchemy 2.0 호환(URL 정규화)

### DIFF
--- a/apps/backend/api/alembic/env.py
+++ b/apps/backend/api/alembic/env.py
@@ -15,6 +15,8 @@ target_metadata = None
 database_url = os.environ.get("DATABASE_URL")
 if not database_url:
     raise RuntimeError("DATABASE_URL 환경변수가 설정되지 않았습니다.")
+# SQLAlchemy 2.0은 postgres:// 미지원 → postgresql://로 정규화
+database_url = database_url.replace("postgres://", "postgresql://", 1)
 config.set_main_option("sqlalchemy.url", database_url)
 
 

--- a/apps/backend/api/src/db.py
+++ b/apps/backend/api/src/db.py
@@ -19,7 +19,9 @@ _ALEMBIC_INI = Path(__file__).resolve().parents[1] / "alembic.ini"
 
 def _run_migrations() -> None:
     cfg = Config(_ALEMBIC_INI)
-    cfg.set_main_option("sqlalchemy.url", os.environ["DATABASE_URL"])
+    # SQLAlchemy 2.0은 postgres:// 미지원 → postgresql://로 정규화
+    url = os.environ["DATABASE_URL"].replace("postgres://", "postgresql://", 1)
+    cfg.set_main_option("sqlalchemy.url", url)
     command.upgrade(cfg, "head")
     logger.info("DB 마이그레이션 완료 (alembic upgrade head)")
 


### PR DESCRIPTION
## 원인
SQLAlchemy 2.0은 `postgres://` scheme을 지원하지 않음. 
Alembic 도입 전 psycopg2 직접 사용 시에는 문제 없었으나 `alembic upgrade head` 실행 시 SQLAlchemy가 URL을 파싱하면서 에러 발생.                       
                                                                                                
  ## 수정
- `db.py`, `alembic/env.py` 양쪽에서 DATABASE_URL 주입 전 `postgres://` → `postgresql://` 자동 변환 추가          
