### PR TITLE
[Fix] API 키 URL 노출 및 에러 메시지 정보 유출 수정

### DIFF
--- a/apps/backend/api/src/routers/qa.py
+++ b/apps/backend/api/src/routers/qa.py
@@ -199,7 +199,7 @@ def ask(
         )
     except RetrievalError as exc:
         logger.error("ask RetrievalError: %s", exc)
-        raise HTTPException(status_code=502, detail=str(exc)) from exc
+        raise HTTPException(status_code=502, detail="검색 서비스 오류가 발생했습니다.") from exc
     except Exception:
         logger.error("INTERNAL_ERROR in ask:\n%s", traceback.format_exc())
         raise HTTPException(status_code=500, detail="서버 오류가 발생했습니다.")
@@ -303,7 +303,7 @@ def ask_stream(
             yield f"data: {json.dumps(done_payload, ensure_ascii=False)}\n\n"
         except RetrievalError as exc:
             logger.error("ask_stream RetrievalError: %s", exc)
-            yield f"data: {json.dumps({'type': 'error', 'code': 'PIPELINE_ERROR', 'error': str(exc)}, ensure_ascii=False)}\n\n"
+            yield f"data: {json.dumps({'type': 'error', 'code': 'PIPELINE_ERROR', 'error': '검색 서비스 오류가 발생했습니다.'}, ensure_ascii=False)}\n\n"
             return
         except Exception:
             logger.error("INTERNAL_ERROR in ask_stream:\n%s", traceback.format_exc())

--- a/apps/backend/rag/rag_pipeline/generation/llm_client.py
+++ b/apps/backend/rag/rag_pipeline/generation/llm_client.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import json
 import urllib.error
-import urllib.parse
 import urllib.request
 from typing import Any, Iterator
 
@@ -100,9 +99,8 @@ def generate_answer(
             temperature=temperature,
             response_mime_type=response_mime_type,
         )
-        sep = "&" if "?" in url else "?"
-        call_url = f"{url}{sep}key={urllib.parse.quote(api_key)}"
-        res = http_json("POST", call_url, payload, {"Content-Type": "application/json"}, timeout)
+        headers = {"Content-Type": "application/json", "x-goog-api-key": api_key}
+        res = http_json("POST", url, payload, headers, timeout)
         return _extract_text_from_gemini_response(res)
 
     headers = {"Content-Type": "application/json"}
@@ -214,8 +212,7 @@ def _stream_gemini(
         temperature=temperature,
     )
     stream_url = url.replace(":generateContent", ":streamGenerateContent")
-    sep = "&" if "?" in stream_url else "?"
-    call_url = f"{stream_url}{sep}alt=sse&key={urllib.parse.quote(api_key)}"
+    call_url = f"{stream_url}?alt=sse"
 
     req = urllib.request.Request(
         url=call_url,
@@ -223,6 +220,7 @@ def _stream_gemini(
         data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
     )
     req.add_header("Content-Type", "application/json")
+    req.add_header("x-goog-api-key", api_key)
 
     with urllib.request.urlopen(req, timeout=timeout) as resp:
         for raw in resp:


### PR DESCRIPTION
## Work Description
Gemini API 키 노출 가능성과 클라이언트 응답에서의 내부 정보 유출 문제를 수정하여 보안성을 강화했습니다. 또한 API 키 전달 방식을 헤더 기반으로 변경하고, 에러 응답에서 민감한 정보가 외부로 노출되지 않도록 처리했습니다.

## Changes
- Gemini API 키 전달 방식 변경 (llm_client.py)
  - `?key=` 쿼리 파라미터 방식 → `x-goog-api-key` 헤더 방식으로 변경
  - HTTP 에러 발생 시 URL 로그에 API 키가 노출될 수 있는 문제 해결

- 클라이언트 에러 응답 정보 유출 방지 (qa.py)
  - `RetrievalError`의 상세 메시지(`str(exc)`)를 그대로 반환하던 구조 수정
  - `/ask` → HTTP 502 고정 메시지로 변경
  - `/ask/stream` → SSE error 이벤트 메시지 고정으로 변경
  - 내부 에러 상세 정보는 서버 로그에만 기록하도록 분리

## Security
- Fixes GitHub Code Scanning alerts (API key exposure, error leakage)

## Testing
- [x] 로컬 테스트 완료
- [x] 기능 동작 확인
