### PR TITLE
[Refectior] legal-pipeline Neo4j 개선 상하위 관계, 위임 관계 추가 및 하위법령 처리 규칙

### DIFF
--- a/apps/backend/legal-pipeline/src/export/law_graph_exporter.py
+++ b/apps/backend/legal-pipeline/src/export/law_graph_exporter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 from typing import Any
 
 from src.common.io_utils import _iter_jsonl, _write_json, write_jsonl
@@ -116,6 +117,98 @@ def _build_has_child_law_edges(law_nodes: dict[str, dict[str, Any]]) -> list[dic
     return sorted(has_child_law_edges.values(), key=lambda row: str(row.get("edge_id") or ""))
 
 
+_PRESIDENTIAL_DELEGATION_PATTERN = re.compile(r"대통령령")
+_MINISTERIAL_DELEGATION_PATTERN = re.compile(r"(?:[가-힣]+부령|부령|규칙)")
+
+
+def _build_delegates_to_law_edges(
+    *,
+    law_nodes: dict[str, dict[str, Any]],
+    article_nodes: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    family_nodes: dict[str, list[dict[str, Any]]] = {}
+    for node in law_nodes.values():
+        family_key = str(node.get("root_law_uid") or "").strip() or str(node.get("law_uid") or "").strip()
+        if not family_key:
+            continue
+        family_nodes.setdefault(family_key, []).append(node)
+
+    decree_by_family: dict[str, dict[str, Any]] = {}
+    rule_by_family: dict[str, dict[str, Any]] = {}
+    for family_key, nodes in family_nodes.items():
+        ordered = sorted(
+            nodes,
+            key=lambda row: (
+                _law_level_rank(row.get("classified_level")),
+                str(row.get("law_name") or ""),
+                str(row.get("law_uid") or ""),
+            ),
+        )
+        decree = next((row for row in ordered if _clean_str(row.get("classified_level")) == "시행령"), None)
+        rule = next((row for row in ordered if _clean_str(row.get("classified_level")) == "시행규칙"), None)
+        if decree is not None:
+            decree_by_family[family_key] = decree
+        if rule is not None:
+            rule_by_family[family_key] = rule
+
+    merged: dict[str, dict[str, Any]] = {}
+
+    for article in article_nodes.values():
+        source_law_uid = str(article.get("law_uid") or "").strip()
+        source_article_key = str(article.get("article_key") or "").strip()
+        root_law_uid = str(article.get("root_law_uid") or "").strip()
+        source_level = _clean_str(law_nodes.get(source_law_uid, {}).get("classified_level"))
+        text = str(article.get("text") or "")
+        if not source_law_uid or not source_article_key or not root_law_uid or not text:
+            continue
+
+        target_law_uid: str | None = None
+        relation_type: str | None = None
+
+        if source_level == "법" and _PRESIDENTIAL_DELEGATION_PATTERN.search(text):
+            target_law_uid = str(decree_by_family.get(root_law_uid, {}).get("law_uid") or "").strip() or None
+            relation_type = "presidential_decree"
+        elif source_level == "시행령" and _MINISTERIAL_DELEGATION_PATTERN.search(text):
+            target_law_uid = str(rule_by_family.get(root_law_uid, {}).get("law_uid") or "").strip() or None
+            relation_type = "ministerial_rule"
+        elif source_level == "법" and _MINISTERIAL_DELEGATION_PATTERN.search(text) and root_law_uid not in decree_by_family:
+            target_law_uid = str(rule_by_family.get(root_law_uid, {}).get("law_uid") or "").strip() or None
+            relation_type = "ministerial_rule"
+
+        if not target_law_uid or not relation_type or target_law_uid == source_law_uid:
+            continue
+
+        edge_key = _edge_id("DELEGATES_TO_LAW", source_law_uid, target_law_uid)
+        current = merged.get(edge_key)
+        reference_text = _clean_str(article.get("article_no_display")) or source_article_key
+        if current is None:
+            merged[edge_key] = {
+                "edge_id": edge_key,
+                "edge_type": "DELEGATES_TO_LAW",
+                "source_law_uid": source_law_uid,
+                "target_law_uid": target_law_uid,
+                "root_law_uid": root_law_uid,
+                "root_law_name": article.get("root_law_name"),
+                "relation_type": relation_type,
+                "relation_types": [relation_type, "delegation"],
+                "relation_confidence": 0.9,
+                "source_article_keys": [source_article_key],
+                "source_article_no_displays": [_clean_str(article.get("article_no_display"))] if _clean_str(article.get("article_no_display")) else [],
+                "reference_texts": [reference_text],
+            }
+            continue
+
+        current["source_article_keys"] = list(dict.fromkeys(list(current.get("source_article_keys") or []) + [source_article_key]))
+        article_no_display = _clean_str(article.get("article_no_display"))
+        if article_no_display:
+            current["source_article_no_displays"] = list(
+                dict.fromkeys(list(current.get("source_article_no_displays") or []) + [article_no_display])
+            )
+        current["reference_texts"] = list(dict.fromkeys(list(current.get("reference_texts") or []) + [reference_text]))
+
+    return sorted(merged.values(), key=lambda row: str(row.get("edge_id") or ""))
+
+
 def build_law_graph_export_rows(
     *,
     legal_corpus_path: str | Path = "data/dataset/legal_corpus.jsonl",
@@ -128,6 +221,7 @@ def build_law_graph_export_rows(
     article_nodes: dict[str, dict[str, Any]] = {}
     has_article_edges: dict[str, dict[str, Any]] = {}
     has_child_law_edges: list[dict[str, Any]] = []
+    delegates_to_law_edges: list[dict[str, Any]] = []
     refers_to_law_edges: dict[str, dict[str, Any]] = {}
     refers_to_article_edges: dict[str, dict[str, Any]] = {}
 
@@ -221,6 +315,7 @@ def build_law_graph_export_rows(
             node["root_law_name"] = node["law_name"]
 
     has_child_law_edges = _build_has_child_law_edges(law_nodes)
+    delegates_to_law_edges = _build_delegates_to_law_edges(law_nodes=law_nodes, article_nodes=article_nodes)
 
     for row in _iter_jsonl(legal_relations_path):
         if str(row.get("relation_model") or "").strip() != "law_to_law":
@@ -317,6 +412,7 @@ def build_law_graph_export_rows(
         "article_nodes": sorted(article_nodes.values(), key=lambda row: str(row.get("article_uid") or "")),
         "has_article_edges": sorted(has_article_edges.values(), key=lambda row: str(row.get("edge_id") or "")),
         "has_child_law_edges": has_child_law_edges,
+        "delegates_to_law_edges": delegates_to_law_edges,
         "refers_to_law_edges": sorted(refers_to_law_edges.values(), key=lambda row: str(row.get("edge_id") or "")),
         "refers_to_article_edges": sorted(refers_to_article_edges.values(), key=lambda row: str(row.get("edge_id") or "")),
     }
@@ -338,6 +434,7 @@ def write_law_graph_export(
     write_jsonl(rows["article_nodes"], output_dir / "graph_article_nodes.jsonl")
     write_jsonl(rows["has_article_edges"], output_dir / "graph_edges_has_article.jsonl")
     write_jsonl(rows["has_child_law_edges"], output_dir / "graph_edges_has_child_law.jsonl")
+    write_jsonl(rows["delegates_to_law_edges"], output_dir / "graph_edges_delegates_to_law.jsonl")
     write_jsonl(rows["refers_to_law_edges"], output_dir / "graph_edges_refers_to_law.jsonl")
     write_jsonl(rows["refers_to_article_edges"], output_dir / "graph_edges_refers_to_article.jsonl")
 
@@ -346,6 +443,7 @@ def write_law_graph_export(
         "article_node_count": len(rows["article_nodes"]),
         "has_article_edge_count": len(rows["has_article_edges"]),
         "has_child_law_edge_count": len(rows["has_child_law_edges"]),
+        "delegates_to_law_edge_count": len(rows["delegates_to_law_edges"]),
         "refers_to_law_edge_count": len(rows["refers_to_law_edges"]),
         "refers_to_article_edge_count": len(rows["refers_to_article_edges"]),
         "source_legal_corpus_path": str(legal_corpus_path),

--- a/apps/backend/legal-pipeline/src/export/law_graph_exporter.py
+++ b/apps/backend/legal-pipeline/src/export/law_graph_exporter.py
@@ -23,6 +23,99 @@ def _clean_str(value: Any) -> str | None:
     return text or None
 
 
+def _family_key(value: Any) -> str | None:
+    text = _clean_str(value)
+    if not text:
+        return None
+    return (
+        text.replace("ㆍ", "")
+        .replace("·", "")
+        .replace(" ", "")
+        .replace("_", "")
+        .strip()
+        .lower()
+    ) or None
+
+
+def _law_level_rank(classified_level: Any) -> int:
+    level = _clean_str(classified_level)
+    if level == "법":
+        return 0
+    if level == "시행령":
+        return 1
+    if level == "시행규칙":
+        return 2
+    return 3
+
+
+def _build_has_child_law_edges(law_nodes: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    families: dict[str, list[dict[str, Any]]] = {}
+    for node in law_nodes.values():
+        family_key = _family_key(node.get("root_law_name")) or _family_key(node.get("law_name"))
+        if not family_key:
+            continue
+        families.setdefault(family_key, []).append(node)
+
+    has_child_law_edges: dict[str, dict[str, Any]] = {}
+
+    for _family_name_key, family_nodes in families.items():
+        ordered_nodes = sorted(
+            family_nodes,
+            key=lambda row: (
+                _law_level_rank(row.get("classified_level")),
+                str(row.get("law_name") or ""),
+                str(row.get("law_uid") or ""),
+            ),
+        )
+        root_node = next((row for row in ordered_nodes if _clean_str(row.get("classified_level")) == "법"), None)
+        if root_node is None:
+            root_node = ordered_nodes[0] if ordered_nodes else None
+        if root_node is None:
+            continue
+
+        root_law_uid = str(root_node.get("law_uid") or "").strip()
+        if not root_law_uid:
+            continue
+
+        decree_node = next(
+            (
+                row
+                for row in ordered_nodes
+                if str(row.get("law_uid") or "").strip() != root_law_uid
+                and _clean_str(row.get("classified_level")) == "시행령"
+            ),
+            None,
+        )
+
+        for node in ordered_nodes:
+            law_uid = str(node.get("law_uid") or "").strip()
+            if not law_uid or law_uid == root_law_uid:
+                continue
+
+            parent_law_uid = root_law_uid
+            if (
+                decree_node is not None
+                and str(decree_node.get("law_uid") or "").strip() != law_uid
+                and _clean_str(node.get("classified_level")) == "시행규칙"
+            ):
+                parent_law_uid = str(decree_node.get("law_uid") or "").strip()
+
+            edge_key = _edge_id("HAS_CHILD_LAW", parent_law_uid, law_uid)
+            has_child_law_edges.setdefault(
+                edge_key,
+                {
+                    "edge_id": edge_key,
+                    "edge_type": "HAS_CHILD_LAW",
+                    "source_law_uid": parent_law_uid,
+                    "target_law_uid": law_uid,
+                    "root_law_uid": root_law_uid,
+                    "root_law_name": _clean_str(root_node.get("law_name")),
+                },
+            )
+
+    return sorted(has_child_law_edges.values(), key=lambda row: str(row.get("edge_id") or ""))
+
+
 def build_law_graph_export_rows(
     *,
     legal_corpus_path: str | Path = "data/dataset/legal_corpus.jsonl",
@@ -34,6 +127,7 @@ def build_law_graph_export_rows(
     law_nodes: dict[str, dict[str, Any]] = {}
     article_nodes: dict[str, dict[str, Any]] = {}
     has_article_edges: dict[str, dict[str, Any]] = {}
+    has_child_law_edges: list[dict[str, Any]] = []
     refers_to_law_edges: dict[str, dict[str, Any]] = {}
     refers_to_article_edges: dict[str, dict[str, Any]] = {}
 
@@ -92,19 +186,41 @@ def build_law_graph_export_rows(
             },
         )
 
+    family_roots: dict[str, dict[str, Any]] = {}
+    for node in sorted(
+        law_nodes.values(),
+        key=lambda row: (
+            _family_key(row.get("root_law_name")) or _family_key(row.get("law_name")) or "",
+            _law_level_rank(row.get("classified_level")),
+            str(row.get("law_name") or ""),
+        ),
+    ):
+        family_key = _family_key(node.get("root_law_name")) or _family_key(node.get("law_name"))
+        if not family_key:
+            continue
+        current = family_roots.get(family_key)
+        if current is None or _law_level_rank(node.get("classified_level")) < _law_level_rank(current.get("classified_level")):
+            family_roots[family_key] = node
+
     for node in law_nodes.values():
-        root_law_uid = _clean_str(node.get("root_law_uid"))
-        if root_law_uid and root_law_uid in law_nodes:
-            node["root_law_name"] = law_nodes[root_law_uid]["law_name"]
+        family_key = _family_key(node.get("root_law_name")) or _family_key(node.get("law_name"))
+        family_root = family_roots.get(family_key) if family_key else None
+        if family_root is not None:
+            node["root_law_uid"] = family_root["law_uid"]
+            node["root_law_name"] = family_root["law_name"]
         elif not _clean_str(node.get("root_law_name")):
             node["root_law_name"] = node["law_name"]
 
     for node in article_nodes.values():
-        root_law_uid = _clean_str(node.get("root_law_uid"))
-        if root_law_uid and root_law_uid in law_nodes:
-            node["root_law_name"] = law_nodes[root_law_uid]["law_name"]
+        family_key = _family_key(node.get("root_law_name")) or _family_key(node.get("law_name"))
+        family_root = family_roots.get(family_key) if family_key else None
+        if family_root is not None:
+            node["root_law_uid"] = family_root["law_uid"]
+            node["root_law_name"] = family_root["law_name"]
         elif not _clean_str(node.get("root_law_name")):
             node["root_law_name"] = node["law_name"]
+
+    has_child_law_edges = _build_has_child_law_edges(law_nodes)
 
     for row in _iter_jsonl(legal_relations_path):
         if str(row.get("relation_model") or "").strip() != "law_to_law":
@@ -200,6 +316,7 @@ def build_law_graph_export_rows(
         "law_nodes": sorted(law_nodes.values(), key=lambda row: str(row.get("law_uid") or "")),
         "article_nodes": sorted(article_nodes.values(), key=lambda row: str(row.get("article_uid") or "")),
         "has_article_edges": sorted(has_article_edges.values(), key=lambda row: str(row.get("edge_id") or "")),
+        "has_child_law_edges": has_child_law_edges,
         "refers_to_law_edges": sorted(refers_to_law_edges.values(), key=lambda row: str(row.get("edge_id") or "")),
         "refers_to_article_edges": sorted(refers_to_article_edges.values(), key=lambda row: str(row.get("edge_id") or "")),
     }
@@ -220,6 +337,7 @@ def write_law_graph_export(
     write_jsonl(rows["law_nodes"], output_dir / "graph_law_nodes.jsonl")
     write_jsonl(rows["article_nodes"], output_dir / "graph_article_nodes.jsonl")
     write_jsonl(rows["has_article_edges"], output_dir / "graph_edges_has_article.jsonl")
+    write_jsonl(rows["has_child_law_edges"], output_dir / "graph_edges_has_child_law.jsonl")
     write_jsonl(rows["refers_to_law_edges"], output_dir / "graph_edges_refers_to_law.jsonl")
     write_jsonl(rows["refers_to_article_edges"], output_dir / "graph_edges_refers_to_article.jsonl")
 
@@ -227,6 +345,7 @@ def write_law_graph_export(
         "law_node_count": len(rows["law_nodes"]),
         "article_node_count": len(rows["article_nodes"]),
         "has_article_edge_count": len(rows["has_article_edges"]),
+        "has_child_law_edge_count": len(rows["has_child_law_edges"]),
         "refers_to_law_edge_count": len(rows["refers_to_law_edges"]),
         "refers_to_article_edge_count": len(rows["refers_to_article_edges"]),
         "source_legal_corpus_path": str(legal_corpus_path),

--- a/apps/backend/legal-pipeline/src/export/law_graph_neo4j_seed.py
+++ b/apps/backend/legal-pipeline/src/export/law_graph_neo4j_seed.py
@@ -14,6 +14,7 @@ def load_graph_seed_rows(
         "law_nodes": list(_iter_jsonl(base_dir / "graph_law_nodes.jsonl")),
         "article_nodes": list(_iter_jsonl(base_dir / "graph_article_nodes.jsonl")),
         "has_article_edges": list(_iter_jsonl(base_dir / "graph_edges_has_article.jsonl")),
+        "has_child_law_edges": list(_iter_jsonl(base_dir / "graph_edges_has_child_law.jsonl")),
         "refers_to_law_edges": list(_iter_jsonl(base_dir / "graph_edges_refers_to_law.jsonl")),
         "refers_to_article_edges": list(_iter_jsonl(base_dir / "graph_edges_refers_to_article.jsonl")),
     }
@@ -24,6 +25,7 @@ def build_seed_manifest(rows: dict[str, list[dict[str, Any]]]) -> dict[str, int]
         "law_node_count": len(rows["law_nodes"]),
         "article_node_count": len(rows["article_nodes"]),
         "has_article_edge_count": len(rows["has_article_edges"]),
+        "has_child_law_edge_count": len(rows["has_child_law_edges"]),
         "refers_to_law_edge_count": len(rows["refers_to_law_edges"]),
         "refers_to_article_edge_count": len(rows["refers_to_article_edges"]),
     }
@@ -49,6 +51,14 @@ MERGE (law)-[r:HAS_ARTICLE {edge_id: row.edge_id}]->(article)
 SET r += row
 """.strip()
 
+HAS_CHILD_LAW_QUERY = """
+UNWIND $rows AS row
+MATCH (source:Law {law_uid: row.source_law_uid})
+MATCH (target:Law {law_uid: row.target_law_uid})
+MERGE (source)-[r:HAS_CHILD_LAW {edge_id: row.edge_id}]->(target)
+SET r += row
+""".strip()
+
 REFERS_TO_LAW_QUERY = """
 UNWIND $rows AS row
 MATCH (source:Law {law_uid: row.source_law_uid})
@@ -71,6 +81,7 @@ def iter_seed_operations(rows: dict[str, list[dict[str, Any]]]) -> list[tuple[st
         (LAW_NODE_QUERY, rows["law_nodes"]),
         (ARTICLE_NODE_QUERY, rows["article_nodes"]),
         (HAS_ARTICLE_QUERY, rows["has_article_edges"]),
+        (HAS_CHILD_LAW_QUERY, rows["has_child_law_edges"]),
         (REFERS_TO_LAW_QUERY, rows["refers_to_law_edges"]),
         (REFERS_TO_ARTICLE_QUERY, rows["refers_to_article_edges"]),
     ]

--- a/apps/backend/legal-pipeline/src/export/law_graph_neo4j_seed.py
+++ b/apps/backend/legal-pipeline/src/export/law_graph_neo4j_seed.py
@@ -15,6 +15,7 @@ def load_graph_seed_rows(
         "article_nodes": list(_iter_jsonl(base_dir / "graph_article_nodes.jsonl")),
         "has_article_edges": list(_iter_jsonl(base_dir / "graph_edges_has_article.jsonl")),
         "has_child_law_edges": list(_iter_jsonl(base_dir / "graph_edges_has_child_law.jsonl")),
+        "delegates_to_law_edges": list(_iter_jsonl(base_dir / "graph_edges_delegates_to_law.jsonl")),
         "refers_to_law_edges": list(_iter_jsonl(base_dir / "graph_edges_refers_to_law.jsonl")),
         "refers_to_article_edges": list(_iter_jsonl(base_dir / "graph_edges_refers_to_article.jsonl")),
     }
@@ -26,6 +27,7 @@ def build_seed_manifest(rows: dict[str, list[dict[str, Any]]]) -> dict[str, int]
         "article_node_count": len(rows["article_nodes"]),
         "has_article_edge_count": len(rows["has_article_edges"]),
         "has_child_law_edge_count": len(rows["has_child_law_edges"]),
+        "delegates_to_law_edge_count": len(rows["delegates_to_law_edges"]),
         "refers_to_law_edge_count": len(rows["refers_to_law_edges"]),
         "refers_to_article_edge_count": len(rows["refers_to_article_edges"]),
     }
@@ -59,6 +61,14 @@ MERGE (source)-[r:HAS_CHILD_LAW {edge_id: row.edge_id}]->(target)
 SET r += row
 """.strip()
 
+DELEGATES_TO_LAW_QUERY = """
+UNWIND $rows AS row
+MATCH (source:Law {law_uid: row.source_law_uid})
+MATCH (target:Law {law_uid: row.target_law_uid})
+MERGE (source)-[r:DELEGATES_TO_LAW {edge_id: row.edge_id}]->(target)
+SET r += row
+""".strip()
+
 REFERS_TO_LAW_QUERY = """
 UNWIND $rows AS row
 MATCH (source:Law {law_uid: row.source_law_uid})
@@ -82,6 +92,7 @@ def iter_seed_operations(rows: dict[str, list[dict[str, Any]]]) -> list[tuple[st
         (ARTICLE_NODE_QUERY, rows["article_nodes"]),
         (HAS_ARTICLE_QUERY, rows["has_article_edges"]),
         (HAS_CHILD_LAW_QUERY, rows["has_child_law_edges"]),
+        (DELEGATES_TO_LAW_QUERY, rows["delegates_to_law_edges"]),
         (REFERS_TO_LAW_QUERY, rows["refers_to_law_edges"]),
         (REFERS_TO_ARTICLE_QUERY, rows["refers_to_article_edges"]),
     ]

--- a/apps/backend/legal-pipeline/tests/test_law_graph_exporter.py
+++ b/apps/backend/legal-pipeline/tests/test_law_graph_exporter.py
@@ -137,6 +137,7 @@ def test_build_law_graph_export_rows_dedupes_article_nodes_and_splits_edges(tmp_
     assert len(rows["law_nodes"]) == 2
     assert len(rows["article_nodes"]) == 3
     assert len(rows["has_article_edges"]) == 3
+    assert len(rows["has_child_law_edges"]) == 1
     assert len(rows["refers_to_law_edges"]) == 1
     assert len(rows["refers_to_article_edges"]) == 1
 
@@ -146,6 +147,10 @@ def test_build_law_graph_export_rows_dedupes_article_nodes_and_splits_edges(tmp_
     edge = rows["refers_to_article_edges"][0]
     assert edge["source_article_uid"] == "article::001::10"
     assert edge["target_article_uid"] == "article::001::7"
+
+    hierarchy_edge = rows["has_child_law_edges"][0]
+    assert hierarchy_edge["source_law_uid"] == "001"
+    assert hierarchy_edge["target_law_uid"] == "002"
 
 
 def test_build_law_graph_export_rows_skips_blank_law_name_and_restores_root_law_name(tmp_path):
@@ -214,6 +219,7 @@ def test_build_law_graph_export_rows_skips_blank_law_name_and_restores_root_law_
 
     assert len(rows["law_nodes"]) == 2
     assert len(rows["article_nodes"]) == 2
+    assert len(rows["has_child_law_edges"]) == 1
     assert all(row["law_uid"] != "unknown-law" for row in rows["law_nodes"])
     assert all(row["law_uid"] != "unknown-law" for row in rows["article_nodes"])
 
@@ -222,6 +228,114 @@ def test_build_law_graph_export_rows_skips_blank_law_name_and_restores_root_law_
 
     child_article = next(row for row in rows["article_nodes"] if row["law_uid"] == "003140")
     assert child_article["root_law_name"] == "남녀고용평등과 일ㆍ가정 양립 지원에 관한 법률"
+
+
+def test_build_law_graph_export_rows_builds_family_hierarchy(tmp_path):
+    corpus_path = tmp_path / "dataset" / "legal_corpus.jsonl"
+    relations_path = tmp_path / "dataset" / "legal_relations.jsonl"
+
+    write_jsonl(
+        [
+            {
+                "id": "law::001::article::1::0",
+                "doc_type": "law",
+                "section_type": "article",
+                "law_uid": "001",
+                "law_name": "근로기준법",
+                "root_law_uid": "001",
+                "root_law_name": "근로기준법",
+                "classified_level": "법",
+                "kind_name": "법률",
+                "article_key": "1",
+                "article_no_display": "제1조",
+                "text": "본문",
+                "display_text": "본문",
+                "source_file_path": "law.json",
+            },
+            {
+                "id": "law::002::article::1::0",
+                "doc_type": "law",
+                "section_type": "article",
+                "law_uid": "002",
+                "law_name": "근로기준법 시행령",
+                "root_law_uid": "001",
+                "root_law_name": "근로기준법",
+                "classified_level": "시행령",
+                "kind_name": "대통령령",
+                "article_key": "1",
+                "article_no_display": "제1조",
+                "text": "본문",
+                "display_text": "본문",
+                "source_file_path": "decree.json",
+            },
+            {
+                "id": "law::003::article::1::0",
+                "doc_type": "law",
+                "section_type": "article",
+                "law_uid": "003",
+                "law_name": "근로기준법 시행규칙",
+                "root_law_uid": "001",
+                "root_law_name": "근로기준법",
+                "classified_level": "시행규칙",
+                "kind_name": "고용노동부령",
+                "article_key": "1",
+                "article_no_display": "제1조",
+                "text": "본문",
+                "display_text": "본문",
+                "source_file_path": "rule.json",
+            },
+            {
+                "id": "law::004::article::1::0",
+                "doc_type": "law",
+                "section_type": "article",
+                "law_uid": "004",
+                "law_name": "근로감독관규정",
+                "root_law_uid": "001",
+                "root_law_name": "근로기준법",
+                "classified_level": "기타",
+                "kind_name": "고시",
+                "article_key": "1",
+                "article_no_display": "제1조",
+                "text": "본문",
+                "display_text": "본문",
+                "source_file_path": "other.json",
+            },
+        ],
+        corpus_path,
+    )
+    write_jsonl([], relations_path)
+
+    rows = build_law_graph_export_rows(
+        legal_corpus_path=corpus_path,
+        legal_relations_path=relations_path,
+    )
+
+    assert rows["has_child_law_edges"] == [
+        {
+            "edge_id": "HAS_CHILD_LAW::001::002",
+            "edge_type": "HAS_CHILD_LAW",
+            "source_law_uid": "001",
+            "target_law_uid": "002",
+            "root_law_uid": "001",
+            "root_law_name": "근로기준법",
+        },
+        {
+            "edge_id": "HAS_CHILD_LAW::001::004",
+            "edge_type": "HAS_CHILD_LAW",
+            "source_law_uid": "001",
+            "target_law_uid": "004",
+            "root_law_uid": "001",
+            "root_law_name": "근로기준법",
+        },
+        {
+            "edge_id": "HAS_CHILD_LAW::002::003",
+            "edge_type": "HAS_CHILD_LAW",
+            "source_law_uid": "002",
+            "target_law_uid": "003",
+            "root_law_uid": "001",
+            "root_law_name": "근로기준법",
+        },
+    ]
 
 
 def test_write_law_graph_export_writes_manifest_and_files(tmp_path):
@@ -260,6 +374,8 @@ def test_write_law_graph_export_writes_manifest_and_files(tmp_path):
 
     assert manifest["law_node_count"] == 1
     assert manifest["article_node_count"] == 1
+    assert manifest["has_child_law_edge_count"] == 0
     assert (output_dir / "graph_law_nodes.jsonl").exists()
     assert (output_dir / "graph_article_nodes.jsonl").exists()
+    assert (output_dir / "graph_edges_has_child_law.jsonl").exists()
     assert (output_dir / "graph_manifest.json").exists()

--- a/apps/backend/legal-pipeline/tests/test_law_graph_exporter.py
+++ b/apps/backend/legal-pipeline/tests/test_law_graph_exporter.py
@@ -138,6 +138,7 @@ def test_build_law_graph_export_rows_dedupes_article_nodes_and_splits_edges(tmp_
     assert len(rows["article_nodes"]) == 3
     assert len(rows["has_article_edges"]) == 3
     assert len(rows["has_child_law_edges"]) == 1
+    assert len(rows["delegates_to_law_edges"]) == 0
     assert len(rows["refers_to_law_edges"]) == 1
     assert len(rows["refers_to_article_edges"]) == 1
 
@@ -220,6 +221,7 @@ def test_build_law_graph_export_rows_skips_blank_law_name_and_restores_root_law_
     assert len(rows["law_nodes"]) == 2
     assert len(rows["article_nodes"]) == 2
     assert len(rows["has_child_law_edges"]) == 1
+    assert len(rows["delegates_to_law_edges"]) == 0
     assert all(row["law_uid"] != "unknown-law" for row in rows["law_nodes"])
     assert all(row["law_uid"] != "unknown-law" for row in rows["article_nodes"])
 
@@ -338,6 +340,102 @@ def test_build_law_graph_export_rows_builds_family_hierarchy(tmp_path):
     ]
 
 
+def test_build_law_graph_export_rows_builds_delegation_edges(tmp_path):
+    corpus_path = tmp_path / "dataset" / "legal_corpus.jsonl"
+    relations_path = tmp_path / "dataset" / "legal_relations.jsonl"
+
+    write_jsonl(
+        [
+            {
+                "id": "law::001::article::1::0",
+                "doc_type": "law",
+                "section_type": "article",
+                "law_uid": "001",
+                "law_name": "근로기준법",
+                "root_law_uid": "001",
+                "root_law_name": "근로기준법",
+                "classified_level": "법",
+                "kind_name": "법률",
+                "article_key": "1",
+                "article_no_display": "제1조",
+                "text": "대통령령으로 정한다.",
+                "display_text": "대통령령으로 정한다.",
+                "source_file_path": "law.json",
+            },
+            {
+                "id": "law::002::article::2::0",
+                "doc_type": "law",
+                "section_type": "article",
+                "law_uid": "002",
+                "law_name": "근로기준법 시행령",
+                "root_law_uid": "001",
+                "root_law_name": "근로기준법",
+                "classified_level": "시행령",
+                "kind_name": "대통령령",
+                "article_key": "2",
+                "article_no_display": "제2조",
+                "text": "고용노동부령으로 정한다.",
+                "display_text": "고용노동부령으로 정한다.",
+                "source_file_path": "decree.json",
+            },
+            {
+                "id": "law::003::article::1::0",
+                "doc_type": "law",
+                "section_type": "article",
+                "law_uid": "003",
+                "law_name": "근로기준법 시행규칙",
+                "root_law_uid": "001",
+                "root_law_name": "근로기준법",
+                "classified_level": "시행규칙",
+                "kind_name": "고용노동부령",
+                "article_key": "1",
+                "article_no_display": "제1조",
+                "text": "시행규칙 본문",
+                "display_text": "시행규칙 본문",
+                "source_file_path": "rule.json",
+            },
+        ],
+        corpus_path,
+    )
+    write_jsonl([], relations_path)
+
+    rows = build_law_graph_export_rows(
+        legal_corpus_path=corpus_path,
+        legal_relations_path=relations_path,
+    )
+
+    assert rows["delegates_to_law_edges"] == [
+        {
+            "edge_id": "DELEGATES_TO_LAW::001::002",
+            "edge_type": "DELEGATES_TO_LAW",
+            "source_law_uid": "001",
+            "target_law_uid": "002",
+            "root_law_uid": "001",
+            "root_law_name": "근로기준법",
+            "relation_type": "presidential_decree",
+            "relation_types": ["presidential_decree", "delegation"],
+            "relation_confidence": 0.9,
+            "source_article_keys": ["1"],
+            "source_article_no_displays": ["제1조"],
+            "reference_texts": ["제1조"],
+        },
+        {
+            "edge_id": "DELEGATES_TO_LAW::002::003",
+            "edge_type": "DELEGATES_TO_LAW",
+            "source_law_uid": "002",
+            "target_law_uid": "003",
+            "root_law_uid": "001",
+            "root_law_name": "근로기준법",
+            "relation_type": "ministerial_rule",
+            "relation_types": ["ministerial_rule", "delegation"],
+            "relation_confidence": 0.9,
+            "source_article_keys": ["2"],
+            "source_article_no_displays": ["제2조"],
+            "reference_texts": ["제2조"],
+        },
+    ]
+
+
 def test_write_law_graph_export_writes_manifest_and_files(tmp_path):
     corpus_path = tmp_path / "dataset" / "legal_corpus.jsonl"
     relations_path = tmp_path / "dataset" / "legal_relations.jsonl"
@@ -375,7 +473,9 @@ def test_write_law_graph_export_writes_manifest_and_files(tmp_path):
     assert manifest["law_node_count"] == 1
     assert manifest["article_node_count"] == 1
     assert manifest["has_child_law_edge_count"] == 0
+    assert manifest["delegates_to_law_edge_count"] == 0
     assert (output_dir / "graph_law_nodes.jsonl").exists()
     assert (output_dir / "graph_article_nodes.jsonl").exists()
     assert (output_dir / "graph_edges_has_child_law.jsonl").exists()
+    assert (output_dir / "graph_edges_delegates_to_law.jsonl").exists()
     assert (output_dir / "graph_manifest.json").exists()

--- a/apps/backend/legal-pipeline/tests/test_law_graph_neo4j_seed.py
+++ b/apps/backend/legal-pipeline/tests/test_law_graph_neo4j_seed.py
@@ -2,6 +2,7 @@ from src.common.io_utils import write_jsonl
 from src.export.law_graph_neo4j_seed import (
     ARTICLE_NODE_QUERY,
     HAS_ARTICLE_QUERY,
+    HAS_CHILD_LAW_QUERY,
     LAW_NODE_QUERY,
     REFERS_TO_ARTICLE_QUERY,
     REFERS_TO_LAW_QUERY,
@@ -16,6 +17,7 @@ def test_load_graph_seed_rows_and_manifest(tmp_path):
     write_jsonl([{"law_uid": "001"}], base_dir / "graph_law_nodes.jsonl")
     write_jsonl([{"article_uid": "article::001::1"}], base_dir / "graph_article_nodes.jsonl")
     write_jsonl([{"edge_id": "HAS_ARTICLE::001::article::001::1"}], base_dir / "graph_edges_has_article.jsonl")
+    write_jsonl([{"edge_id": "HAS_CHILD_LAW::001::002"}], base_dir / "graph_edges_has_child_law.jsonl")
     write_jsonl([{"edge_id": "REFERS_TO_LAW::001::002"}], base_dir / "graph_edges_refers_to_law.jsonl")
     write_jsonl([{"edge_id": "REFERS_TO_ARTICLE::article::001::1::article::002::2"}], base_dir / "graph_edges_refers_to_article.jsonl")
 
@@ -26,6 +28,7 @@ def test_load_graph_seed_rows_and_manifest(tmp_path):
         "law_node_count": 1,
         "article_node_count": 1,
         "has_article_edge_count": 1,
+        "has_child_law_edge_count": 1,
         "refers_to_law_edge_count": 1,
         "refers_to_article_edge_count": 1,
     }
@@ -36,6 +39,7 @@ def test_iter_seed_operations_returns_expected_query_order():
         "law_nodes": [{"law_uid": "001"}],
         "article_nodes": [{"article_uid": "article::001::1"}],
         "has_article_edges": [{"edge_id": "HAS_ARTICLE::001::article::001::1"}],
+        "has_child_law_edges": [{"edge_id": "HAS_CHILD_LAW::001::002"}],
         "refers_to_law_edges": [{"edge_id": "REFERS_TO_LAW::001::002"}],
         "refers_to_article_edges": [{"edge_id": "REFERS_TO_ARTICLE::article::001::1::article::002::2"}],
     }
@@ -45,6 +49,7 @@ def test_iter_seed_operations_returns_expected_query_order():
         LAW_NODE_QUERY,
         ARTICLE_NODE_QUERY,
         HAS_ARTICLE_QUERY,
+        HAS_CHILD_LAW_QUERY,
         REFERS_TO_LAW_QUERY,
         REFERS_TO_ARTICLE_QUERY,
     ]

--- a/apps/backend/legal-pipeline/tests/test_law_graph_neo4j_seed.py
+++ b/apps/backend/legal-pipeline/tests/test_law_graph_neo4j_seed.py
@@ -1,6 +1,7 @@
 from src.common.io_utils import write_jsonl
 from src.export.law_graph_neo4j_seed import (
     ARTICLE_NODE_QUERY,
+    DELEGATES_TO_LAW_QUERY,
     HAS_ARTICLE_QUERY,
     HAS_CHILD_LAW_QUERY,
     LAW_NODE_QUERY,
@@ -18,6 +19,7 @@ def test_load_graph_seed_rows_and_manifest(tmp_path):
     write_jsonl([{"article_uid": "article::001::1"}], base_dir / "graph_article_nodes.jsonl")
     write_jsonl([{"edge_id": "HAS_ARTICLE::001::article::001::1"}], base_dir / "graph_edges_has_article.jsonl")
     write_jsonl([{"edge_id": "HAS_CHILD_LAW::001::002"}], base_dir / "graph_edges_has_child_law.jsonl")
+    write_jsonl([{"edge_id": "DELEGATES_TO_LAW::001::002"}], base_dir / "graph_edges_delegates_to_law.jsonl")
     write_jsonl([{"edge_id": "REFERS_TO_LAW::001::002"}], base_dir / "graph_edges_refers_to_law.jsonl")
     write_jsonl([{"edge_id": "REFERS_TO_ARTICLE::article::001::1::article::002::2"}], base_dir / "graph_edges_refers_to_article.jsonl")
 
@@ -29,6 +31,7 @@ def test_load_graph_seed_rows_and_manifest(tmp_path):
         "article_node_count": 1,
         "has_article_edge_count": 1,
         "has_child_law_edge_count": 1,
+        "delegates_to_law_edge_count": 1,
         "refers_to_law_edge_count": 1,
         "refers_to_article_edge_count": 1,
     }
@@ -40,6 +43,7 @@ def test_iter_seed_operations_returns_expected_query_order():
         "article_nodes": [{"article_uid": "article::001::1"}],
         "has_article_edges": [{"edge_id": "HAS_ARTICLE::001::article::001::1"}],
         "has_child_law_edges": [{"edge_id": "HAS_CHILD_LAW::001::002"}],
+        "delegates_to_law_edges": [{"edge_id": "DELEGATES_TO_LAW::001::002"}],
         "refers_to_law_edges": [{"edge_id": "REFERS_TO_LAW::001::002"}],
         "refers_to_article_edges": [{"edge_id": "REFERS_TO_ARTICLE::article::001::1::article::002::2"}],
     }
@@ -50,6 +54,7 @@ def test_iter_seed_operations_returns_expected_query_order():
         ARTICLE_NODE_QUERY,
         HAS_ARTICLE_QUERY,
         HAS_CHILD_LAW_QUERY,
+        DELEGATES_TO_LAW_QUERY,
         REFERS_TO_LAW_QUERY,
         REFERS_TO_ARTICLE_QUERY,
     ]


### PR DESCRIPTION
## Work Description
- 법령 graph 법 체계 구조와  위임 관계를 별도 edge 로 추가

## Changes
-  HAS_CHILD_LAW edge 추가
  - 본법 / 시행령 / 시행규칙 / 일부 예외 하위법령을 family 기준으로 연결
- DELEGATES_TO_LAW edge 추가
  - 조문 본문의 대통령령, 부령, 규칙 표현을 기준으로 위임 관계 생성
- 로컬 Neo4j 기준 export / seed / count 검증 
 
## Testing
최신 export / seed 기준:
 - Law = 25
- Article = 1196
- HAS_ARTICLE = 1196
- HAS_CHILD_LAW = 17
- DELEGATES_TO_LAW = 13
- REFERS_TO_LAW = 23
- REFERS_TO_ARTICLE = 2277

검증:
- self_article_edge_count = 0
- unresolved_external_count = 0

## Related Issue
close #97 
