### PR TITLE
[Refactor] legal-pipeline Neo4j 법령간 관계 추출 개선

### DIFF
--- a/apps/backend/legal-pipeline/src/export/law_graph_exporter.py
+++ b/apps/backend/legal-pipeline/src/export/law_graph_exporter.py
@@ -5,6 +5,8 @@ import re
 from typing import Any
 
 from src.common.io_utils import _iter_jsonl, _write_json, write_jsonl
+from src.common.law_meta import normalize_classified_level
+from src.parser.law_reference_parser import parse_law_article_references
 
 
 def _article_uid(law_uid: str | None, article_key: str | None) -> str | None:
@@ -38,8 +40,26 @@ def _family_key(value: Any) -> str | None:
     ) or None
 
 
-def _law_level_rank(classified_level: Any) -> int:
-    level = _clean_str(classified_level)
+def _merge_string_list(existing: list[str] | None, new_values: list[str] | None) -> list[str]:
+    merged: list[str] = []
+    seen: set[str] = set()
+
+    for value in list(existing or []) + list(new_values or []):
+        text = str(value or "").strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        merged.append(text)
+
+    return merged
+
+
+def _normalized_law_level(row: dict[str, Any]) -> str:
+    return normalize_classified_level(row.get("kind_name"), row.get("classified_level"))
+
+
+def _law_level_rank(classified_level: Any, kind_name: Any = None) -> int:
+    level = normalize_classified_level(kind_name, classified_level)
     if level == "법":
         return 0
     if level == "시행령":
@@ -49,57 +69,127 @@ def _law_level_rank(classified_level: Any) -> int:
     return 3
 
 
-def _build_has_child_law_edges(law_nodes: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
-    families: dict[str, list[dict[str, Any]]] = {}
+def _law_branch_key(node: dict[str, Any], *, root_law_name: str | None) -> str | None:
+    law_name = _clean_str(node.get("law_name"))
+    if not law_name:
+        return None
+
+    root_name = _clean_str(root_law_name)
+    level = _normalized_law_level(node)
+    if root_name and level in {"시행령", "시행규칙"} and law_name.startswith(root_name):
+        return _family_key(root_name)
+
+    stem = law_name
+    for suffix in ("시행규칙", "시행령", "대통령령", "부령", "규칙", "조례", "규정", "훈령", "예규", "고시"):
+        if stem.endswith(suffix):
+            stem = stem[: -len(suffix)].strip()
+            break
+
+    return _family_key(stem) or _family_key(law_name)
+
+
+def _build_family_index(law_nodes: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    grouped: dict[str, list[dict[str, Any]]] = {}
     for node in law_nodes.values():
-        family_key = _family_key(node.get("root_law_name")) or _family_key(node.get("law_name"))
-        if not family_key:
+        family_id = (
+            str(node.get("root_law_uid") or "").strip()
+            or _family_key(node.get("root_law_name"))
+            or _family_key(node.get("law_name"))
+            or str(node.get("law_uid") or "").strip()
+        )
+        if not family_id:
             continue
-        families.setdefault(family_key, []).append(node)
+        grouped.setdefault(family_id, []).append(node)
 
-    has_child_law_edges: dict[str, dict[str, Any]] = {}
-
-    for _family_name_key, family_nodes in families.items():
-        ordered_nodes = sorted(
-            family_nodes,
+    families: dict[str, dict[str, Any]] = {}
+    for nodes in grouped.values():
+        ordered = sorted(
+            nodes,
             key=lambda row: (
-                _law_level_rank(row.get("classified_level")),
+                _law_level_rank(row.get("classified_level"), row.get("kind_name")),
                 str(row.get("law_name") or ""),
                 str(row.get("law_uid") or ""),
             ),
         )
-        root_node = next((row for row in ordered_nodes if _clean_str(row.get("classified_level")) == "법"), None)
-        if root_node is None:
-            root_node = ordered_nodes[0] if ordered_nodes else None
-        if root_node is None:
+        if not ordered:
             continue
 
-        root_law_uid = str(root_node.get("law_uid") or "").strip()
-        if not root_law_uid:
+        root = next((row for row in ordered if _normalized_law_level(row) == "법"), ordered[0])
+        root_uid = str(root.get("law_uid") or "").strip()
+        root_name = _clean_str(root.get("law_name"))
+        if not root_uid or not root_name:
             continue
 
-        decree_node = next(
-            (
-                row
-                for row in ordered_nodes
-                if str(row.get("law_uid") or "").strip() != root_law_uid
-                and _clean_str(row.get("classified_level")) == "시행령"
-            ),
-            None,
-        )
+        decrees_by_branch: dict[str, list[dict[str, Any]]] = {}
+        rules_by_branch: dict[str, list[dict[str, Any]]] = {}
+        branch_by_uid: dict[str, str] = {}
+        level_by_uid: dict[str, str] = {}
 
-        for node in ordered_nodes:
+        for node in ordered:
+            law_uid = str(node.get("law_uid") or "").strip()
+            if not law_uid:
+                continue
+            level = _normalized_law_level(node)
+            branch_key = _law_branch_key(node, root_law_name=root_name) or root_uid
+            branch_by_uid[law_uid] = branch_key
+            level_by_uid[law_uid] = level
+            if level == "시행령":
+                decrees_by_branch.setdefault(branch_key, []).append(node)
+            elif level == "시행규칙":
+                rules_by_branch.setdefault(branch_key, []).append(node)
+
+        families[root_uid] = {
+            "root": root,
+            "root_law_uid": root_uid,
+            "root_law_name": root_name,
+            "root_branch_key": _law_branch_key(root, root_law_name=root_name) or root_uid,
+            "nodes": ordered,
+            "branch_by_uid": branch_by_uid,
+            "level_by_uid": level_by_uid,
+            "decrees_by_branch": decrees_by_branch,
+            "rules_by_branch": rules_by_branch,
+        }
+
+    return families
+
+
+def _unique_family_member(family: dict[str, Any], *, level: str, branch_key: str | None) -> dict[str, Any] | None:
+    if not branch_key:
+        return None
+
+    if level == "시행령":
+        candidates = list(family.get("decrees_by_branch", {}).get(branch_key, []))
+    elif level == "시행규칙":
+        candidates = list(family.get("rules_by_branch", {}).get(branch_key, []))
+    else:
+        return None
+
+    return candidates[0] if len(candidates) == 1 else None
+
+
+def _build_has_child_law_edges(family_index: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    has_child_law_edges: dict[str, dict[str, Any]] = {}
+
+    for family in family_index.values():
+        root_law_uid = str(family.get("root_law_uid") or "").strip()
+        root_law_name = _clean_str(family.get("root_law_name"))
+        if not root_law_uid or not root_law_name:
+            continue
+
+        for node in family.get("nodes", []):
             law_uid = str(node.get("law_uid") or "").strip()
             if not law_uid or law_uid == root_law_uid:
                 continue
 
+            level = str(family.get("level_by_uid", {}).get(law_uid) or "").strip()
             parent_law_uid = root_law_uid
-            if (
-                decree_node is not None
-                and str(decree_node.get("law_uid") or "").strip() != law_uid
-                and _clean_str(node.get("classified_level")) == "시행규칙"
-            ):
-                parent_law_uid = str(decree_node.get("law_uid") or "").strip()
+
+            if level == "시행규칙":
+                branch_key = family.get("branch_by_uid", {}).get(law_uid)
+                decree_node = _unique_family_member(family, level="시행령", branch_key=branch_key)
+                decree_uid = str(decree_node.get("law_uid") or "").strip() if decree_node else None
+                if decree_uid and decree_uid != law_uid:
+                    parent_law_uid = decree_uid
 
             edge_key = _edge_id("HAS_CHILD_LAW", parent_law_uid, law_uid)
             has_child_law_edges.setdefault(
@@ -110,7 +200,7 @@ def _build_has_child_law_edges(law_nodes: dict[str, dict[str, Any]]) -> list[dic
                     "source_law_uid": parent_law_uid,
                     "target_law_uid": law_uid,
                     "root_law_uid": root_law_uid,
-                    "root_law_name": _clean_str(root_node.get("law_name")),
+                    "root_law_name": root_law_name,
                 },
             )
 
@@ -125,56 +215,38 @@ def _build_delegates_to_law_edges(
     *,
     law_nodes: dict[str, dict[str, Any]],
     article_nodes: dict[str, dict[str, Any]],
+    family_index: dict[str, dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    family_nodes: dict[str, list[dict[str, Any]]] = {}
-    for node in law_nodes.values():
-        family_key = str(node.get("root_law_uid") or "").strip() or str(node.get("law_uid") or "").strip()
-        if not family_key:
-            continue
-        family_nodes.setdefault(family_key, []).append(node)
-
-    decree_by_family: dict[str, dict[str, Any]] = {}
-    rule_by_family: dict[str, dict[str, Any]] = {}
-    for family_key, nodes in family_nodes.items():
-        ordered = sorted(
-            nodes,
-            key=lambda row: (
-                _law_level_rank(row.get("classified_level")),
-                str(row.get("law_name") or ""),
-                str(row.get("law_uid") or ""),
-            ),
-        )
-        decree = next((row for row in ordered if _clean_str(row.get("classified_level")) == "시행령"), None)
-        rule = next((row for row in ordered if _clean_str(row.get("classified_level")) == "시행규칙"), None)
-        if decree is not None:
-            decree_by_family[family_key] = decree
-        if rule is not None:
-            rule_by_family[family_key] = rule
-
     merged: dict[str, dict[str, Any]] = {}
 
     for article in article_nodes.values():
         source_law_uid = str(article.get("law_uid") or "").strip()
         source_article_key = str(article.get("article_key") or "").strip()
         root_law_uid = str(article.get("root_law_uid") or "").strip()
-        source_level = _clean_str(law_nodes.get(source_law_uid, {}).get("classified_level"))
         text = str(article.get("text") or "")
-        if not source_law_uid or not source_article_key or not root_law_uid or not text:
+        source_law = law_nodes.get(source_law_uid, {})
+        family = family_index.get(root_law_uid, {})
+        source_level = _normalized_law_level(source_law) if source_law else None
+        branch_key = family.get("branch_by_uid", {}).get(source_law_uid)
+        if not source_law_uid or not source_article_key or not root_law_uid or not text or not branch_key:
             continue
 
-        target_law_uid: str | None = None
+        target_node: dict[str, Any] | None = None
         relation_type: str | None = None
 
         if source_level == "법" and _PRESIDENTIAL_DELEGATION_PATTERN.search(text):
-            target_law_uid = str(decree_by_family.get(root_law_uid, {}).get("law_uid") or "").strip() or None
+            target_node = _unique_family_member(family, level="시행령", branch_key=branch_key)
             relation_type = "presidential_decree"
         elif source_level == "시행령" and _MINISTERIAL_DELEGATION_PATTERN.search(text):
-            target_law_uid = str(rule_by_family.get(root_law_uid, {}).get("law_uid") or "").strip() or None
+            target_node = _unique_family_member(family, level="시행규칙", branch_key=branch_key)
             relation_type = "ministerial_rule"
-        elif source_level == "법" and _MINISTERIAL_DELEGATION_PATTERN.search(text) and root_law_uid not in decree_by_family:
-            target_law_uid = str(rule_by_family.get(root_law_uid, {}).get("law_uid") or "").strip() or None
-            relation_type = "ministerial_rule"
+        elif source_level == "법" and _MINISTERIAL_DELEGATION_PATTERN.search(text):
+            decree_node = _unique_family_member(family, level="시행령", branch_key=branch_key)
+            if decree_node is None:
+                target_node = _unique_family_member(family, level="시행규칙", branch_key=branch_key)
+                relation_type = "ministerial_rule"
 
+        target_law_uid = str(target_node.get("law_uid") or "").strip() if target_node else None
         if not target_law_uid or not relation_type or target_law_uid == source_law_uid:
             continue
 
@@ -198,15 +270,312 @@ def _build_delegates_to_law_edges(
             }
             continue
 
-        current["source_article_keys"] = list(dict.fromkeys(list(current.get("source_article_keys") or []) + [source_article_key]))
+        current["source_article_keys"] = _merge_string_list(current.get("source_article_keys"), [source_article_key])
         article_no_display = _clean_str(article.get("article_no_display"))
         if article_no_display:
-            current["source_article_no_displays"] = list(
-                dict.fromkeys(list(current.get("source_article_no_displays") or []) + [article_no_display])
+            current["source_article_no_displays"] = _merge_string_list(
+                current.get("source_article_no_displays"),
+                [article_no_display],
             )
-        current["reference_texts"] = list(dict.fromkeys(list(current.get("reference_texts") or []) + [reference_text]))
+        current["reference_texts"] = _merge_string_list(current.get("reference_texts"), [reference_text])
 
     return sorted(merged.values(), key=lambda row: str(row.get("edge_id") or ""))
+
+
+def _build_law_name_index(law_nodes: dict[str, dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    index: dict[str, list[dict[str, Any]]] = {}
+    for node in law_nodes.values():
+        key = _family_key(node.get("law_name"))
+        if not key:
+            continue
+        index.setdefault(key, []).append(node)
+    return index
+
+
+def _resolve_target_law_node(
+    reference: dict[str, Any],
+    *,
+    law_name_index: dict[str, list[dict[str, Any]]],
+) -> dict[str, Any] | None:
+    target_law_name = _clean_str(reference.get("target_law_name"))
+    if target_law_name:
+        direct_matches = list(law_name_index.get(_family_key(target_law_name) or "", []))
+        if len(direct_matches) == 1:
+            return direct_matches[0]
+
+    candidate_nodes: dict[str, dict[str, Any]] = {}
+    for candidate_name in [target_law_name] + list(reference.get("related_law_names") or []):
+        key = _family_key(candidate_name)
+        if not key:
+            continue
+        for node in law_name_index.get(key, []):
+            law_uid = str(node.get("law_uid") or "").strip()
+            if law_uid:
+                candidate_nodes[law_uid] = node
+
+    return next(iter(candidate_nodes.values())) if len(candidate_nodes) == 1 else None
+
+
+def _reference_article_details(reference: dict[str, Any]) -> list[dict[str, str | None]]:
+    details: list[dict[str, str | None]] = []
+    for detail in list(reference.get("target_article_ref_details") or []):
+        article_key = str(detail.get("article_key") or "").strip()
+        if not article_key:
+            continue
+        details.append(
+            {
+                "article_key": article_key,
+                "article_no_display": _clean_str(detail.get("article_no_display")) or article_key,
+                "paragraph_no": _clean_str(detail.get("paragraph_no")),
+                "item_no": _clean_str(detail.get("item_no")),
+                "subitem_no": _clean_str(detail.get("subitem_no")),
+            }
+        )
+
+    if details:
+        return details
+
+    article_keys = [str(item).strip() for item in list(reference.get("target_article_keys") or []) if str(item).strip()]
+    article_no_displays = [str(item).strip() for item in list(reference.get("target_article_no_displays") or []) if str(item).strip()]
+    display_by_key = dict(zip(article_keys, article_no_displays))
+    return [
+        {
+            "article_key": article_key,
+            "article_no_display": display_by_key.get(article_key) or article_key,
+            "paragraph_no": None,
+            "item_no": None,
+            "subitem_no": None,
+        }
+        for article_key in article_keys
+    ]
+
+
+def _build_relation_types(
+    *,
+    base_relation_type: str,
+    reference_type: str,
+    source_law_uid: str,
+    target_law_uid: str,
+) -> list[str]:
+    relation_types = [base_relation_type, reference_type]
+    if source_law_uid == target_law_uid:
+        relation_types.append("same_law_reference")
+    if reference_type in {"previous_article", "next_article", "current_article", "relative_scope"}:
+        relation_types.append("relative_reference")
+    if reference_type == "bare_law_name":
+        relation_types.append("explicit_law_name")
+    return _merge_string_list([], relation_types)
+
+
+def _compile_flexible_space_pattern(text: str, *, with_boundaries: bool) -> re.Pattern[str] | None:
+    normalized = str(text or "").strip()
+    if not normalized:
+        return None
+    tokens = [re.escape(token) for token in re.split(r"\s+", normalized) if token]
+    if not tokens:
+        return None
+    joined = r"\s*".join(tokens)
+    if with_boundaries:
+        joined = rf"(?<![가-힣0-9]){joined}"
+    return re.compile(joined)
+
+
+def _mask_first(text: str, fragment: str) -> str:
+    pattern = _compile_flexible_space_pattern(fragment, with_boundaries=False)
+    if pattern is None:
+        return text
+    match = pattern.search(text)
+    if match is None:
+        return text
+    return text[: match.start()] + (" " * (match.end() - match.start())) + text[match.end() :]
+
+
+def _extract_bare_law_mentions(
+    text: str,
+    *,
+    law_nodes: dict[str, dict[str, Any]],
+    parsed_references: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    masked_text = str(text or "")
+    for fragment in sorted(
+        {
+            str(reference.get("reference_text") or "").strip()
+            for reference in parsed_references
+            if str(reference.get("reference_text") or "").strip()
+        },
+        key=len,
+        reverse=True,
+    ):
+        masked_text = _mask_first(masked_text, fragment)
+
+    mentions: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    candidates = sorted(
+        (
+            _clean_str(node.get("law_name"))
+            for node in law_nodes.values()
+            if _clean_str(node.get("law_name"))
+        ),
+        key=lambda value: (-len(str(value or "")), str(value or "")),
+    )
+
+    for law_name in candidates:
+        if not law_name:
+            continue
+        pattern = _compile_flexible_space_pattern(law_name, with_boundaries=True)
+        if pattern is None:
+            continue
+
+        while True:
+            match = pattern.search(masked_text)
+            if match is None:
+                break
+
+            if law_name not in seen:
+                seen.add(law_name)
+                mentions.append(
+                    {
+                        "law_name": law_name,
+                        "reference_text": _clean_str(match.group(0)) or law_name,
+                        "resolution_confidence": 0.8,
+                    }
+                )
+
+            masked_text = masked_text[: match.start()] + (" " * (match.end() - match.start())) + masked_text[match.end() :]
+
+    return mentions
+
+
+def _upsert_refers_to_law_edge(
+    merged: dict[str, dict[str, Any]],
+    *,
+    source_law_uid: str,
+    target_law_uid: str,
+    root_law_uid: str,
+    root_law_name: str | None,
+    source_article_key: str,
+    source_article_no_display: str | None,
+    relation_types: list[str],
+    relation_confidence: float,
+    reference_text: str,
+    target_article_details: list[dict[str, str | None]] | None = None,
+) -> None:
+    if not source_law_uid or not target_law_uid or source_law_uid == target_law_uid:
+        return
+
+    target_article_details = list(target_article_details or [])
+    edge_key = _edge_id("REFERS_TO_LAW", source_law_uid, target_law_uid)
+    target_article_keys = [str(item.get("article_key") or "").strip() for item in target_article_details if str(item.get("article_key") or "").strip()]
+    target_article_no_displays = [str(item.get("article_no_display") or "").strip() for item in target_article_details if str(item.get("article_no_display") or "").strip()]
+    target_paragraph_nos = [str(item.get("paragraph_no") or "").strip() for item in target_article_details if str(item.get("paragraph_no") or "").strip()]
+    target_item_nos = [str(item.get("item_no") or "").strip() for item in target_article_details if str(item.get("item_no") or "").strip()]
+    target_subitem_nos = [str(item.get("subitem_no") or "").strip() for item in target_article_details if str(item.get("subitem_no") or "").strip()]
+
+    current = merged.get(edge_key)
+    if current is None:
+        merged[edge_key] = {
+            "edge_id": edge_key,
+            "edge_type": "REFERS_TO_LAW",
+            "source_law_uid": source_law_uid,
+            "target_law_uid": target_law_uid,
+            "root_law_uid": root_law_uid,
+            "root_law_name": root_law_name,
+            "relation_type": "cited_law",
+            "relation_types": _merge_string_list([], relation_types),
+            "resolution_status": "resolved",
+            "relation_confidence": relation_confidence,
+            "source_article_keys": [source_article_key],
+            "source_article_no_displays": [source_article_no_display] if source_article_no_display else [],
+            "target_article_keys": target_article_keys,
+            "target_article_no_displays": target_article_no_displays,
+            "target_paragraph_nos": target_paragraph_nos,
+            "target_item_nos": target_item_nos,
+            "target_subitem_nos": target_subitem_nos,
+            "reference_texts": [reference_text],
+        }
+        return
+
+    current["relation_types"] = _merge_string_list(current.get("relation_types"), relation_types)
+    current["relation_confidence"] = max(float(current.get("relation_confidence") or 0), relation_confidence)
+    current["source_article_keys"] = _merge_string_list(current.get("source_article_keys"), [source_article_key])
+    current["source_article_no_displays"] = _merge_string_list(
+        current.get("source_article_no_displays"),
+        [source_article_no_display] if source_article_no_display else [],
+    )
+    current["target_article_keys"] = _merge_string_list(current.get("target_article_keys"), target_article_keys)
+    current["target_article_no_displays"] = _merge_string_list(
+        current.get("target_article_no_displays"),
+        target_article_no_displays,
+    )
+    current["target_paragraph_nos"] = _merge_string_list(current.get("target_paragraph_nos"), target_paragraph_nos)
+    current["target_item_nos"] = _merge_string_list(current.get("target_item_nos"), target_item_nos)
+    current["target_subitem_nos"] = _merge_string_list(current.get("target_subitem_nos"), target_subitem_nos)
+    current["reference_texts"] = _merge_string_list(current.get("reference_texts"), [reference_text])
+
+
+def _upsert_refers_to_article_edge(
+    merged: dict[str, dict[str, Any]],
+    *,
+    source_article_uid: str,
+    target_article_uid: str,
+    source_law_uid: str,
+    target_law_uid: str,
+    source_article_key: str,
+    source_article_no_display: str | None,
+    target_detail: dict[str, str | None],
+    relation_types: list[str],
+    relation_confidence: float,
+    reference_text: str,
+) -> None:
+    if not source_article_uid or not target_article_uid or source_article_uid == target_article_uid:
+        return
+
+    edge_key = _edge_id("REFERS_TO_ARTICLE", source_article_uid, target_article_uid)
+    target_article_key = str(target_detail.get("article_key") or "").strip()
+    target_article_no_display = _clean_str(target_detail.get("article_no_display")) or target_article_key
+    target_paragraph_no = _clean_str(target_detail.get("paragraph_no"))
+    target_item_no = _clean_str(target_detail.get("item_no"))
+    target_subitem_no = _clean_str(target_detail.get("subitem_no"))
+
+    current = merged.get(edge_key)
+    if current is None:
+        merged[edge_key] = {
+            "edge_id": edge_key,
+            "edge_type": "REFERS_TO_ARTICLE",
+            "source_article_uid": source_article_uid,
+            "target_article_uid": target_article_uid,
+            "source_law_uid": source_law_uid,
+            "target_law_uid": target_law_uid,
+            "source_article_key": source_article_key,
+            "source_article_no_display": source_article_no_display,
+            "target_article_key": target_article_key,
+            "target_article_no_display": target_article_no_display,
+            "relation_type": "related_law",
+            "relation_types": _merge_string_list([], relation_types),
+            "resolution_status": "resolved",
+            "relation_confidence": relation_confidence,
+            "target_paragraph_nos": [target_paragraph_no] if target_paragraph_no else [],
+            "target_item_nos": [target_item_no] if target_item_no else [],
+            "target_subitem_nos": [target_subitem_no] if target_subitem_no else [],
+            "reference_texts": [reference_text],
+        }
+        return
+
+    current["relation_types"] = _merge_string_list(current.get("relation_types"), relation_types)
+    current["relation_confidence"] = max(float(current.get("relation_confidence") or 0), relation_confidence)
+    current["target_paragraph_nos"] = _merge_string_list(
+        current.get("target_paragraph_nos"),
+        [target_paragraph_no] if target_paragraph_no else [],
+    )
+    current["target_item_nos"] = _merge_string_list(
+        current.get("target_item_nos"),
+        [target_item_no] if target_item_no else [],
+    )
+    current["target_subitem_nos"] = _merge_string_list(
+        current.get("target_subitem_nos"),
+        [target_subitem_no] if target_subitem_no else [],
+    )
+    current["reference_texts"] = _merge_string_list(current.get("reference_texts"), [reference_text])
 
 
 def build_law_graph_export_rows(
@@ -224,6 +593,8 @@ def build_law_graph_export_rows(
     delegates_to_law_edges: list[dict[str, Any]] = []
     refers_to_law_edges: dict[str, dict[str, Any]] = {}
     refers_to_article_edges: dict[str, dict[str, Any]] = {}
+    article_orders_by_law: dict[str, list[dict[str, str]]] = {}
+    seen_article_keys_by_law: dict[str, set[str]] = {}
 
     for row in _iter_jsonl(legal_corpus_path):
         if str(row.get("doc_type") or "").strip() != "law":
@@ -235,6 +606,7 @@ def build_law_graph_export_rows(
         law_name = _clean_str(row.get("law_name"))
         article_key = str(row.get("article_key") or "").strip()
         article_uid = _article_uid(law_uid, article_key)
+        normalized_level = normalize_classified_level(row.get("kind_name"), row.get("classified_level"))
         if not law_uid or not law_name or not article_uid:
             continue
 
@@ -245,12 +617,22 @@ def build_law_graph_export_rows(
                 "law_name": law_name,
                 "root_law_uid": row.get("root_law_uid"),
                 "root_law_name": row.get("root_law_name"),
-                "classified_level": row.get("classified_level"),
+                "classified_level": normalized_level,
                 "kind_name": row.get("kind_name"),
                 "ef_yd": row.get("ef_yd"),
                 "law_id": row.get("law_id"),
                 "mst": row.get("mst"),
             }
+
+        seen_article_keys_by_law.setdefault(law_uid, set())
+        if article_key and article_key not in seen_article_keys_by_law[law_uid]:
+            article_orders_by_law.setdefault(law_uid, []).append(
+                {
+                    "article_key": article_key,
+                    "article_no_display": str(row.get("article_no_display") or article_key).strip(),
+                }
+            )
+            seen_article_keys_by_law[law_uid].add(article_key)
 
         current_article = article_nodes.get(article_uid)
         candidate_text = str(row.get("text") or "")
@@ -262,6 +644,8 @@ def build_law_graph_export_rows(
                 "root_law_uid": row.get("root_law_uid"),
                 "law_name": law_name,
                 "root_law_name": row.get("root_law_name"),
+                "classified_level": normalized_level,
+                "kind_name": row.get("kind_name"),
                 "article_key": article_key,
                 "article_no_display": row.get("article_no_display"),
                 "text": row.get("text"),
@@ -285,7 +669,7 @@ def build_law_graph_export_rows(
         law_nodes.values(),
         key=lambda row: (
             _family_key(row.get("root_law_name")) or _family_key(row.get("law_name")) or "",
-            _law_level_rank(row.get("classified_level")),
+            _law_level_rank(row.get("classified_level"), row.get("kind_name")),
             str(row.get("law_name") or ""),
         ),
     ):
@@ -293,7 +677,10 @@ def build_law_graph_export_rows(
         if not family_key:
             continue
         current = family_roots.get(family_key)
-        if current is None or _law_level_rank(node.get("classified_level")) < _law_level_rank(current.get("classified_level")):
+        if current is None or _law_level_rank(node.get("classified_level"), node.get("kind_name")) < _law_level_rank(
+            current.get("classified_level"),
+            current.get("kind_name"),
+        ):
             family_roots[family_key] = node
 
     for node in law_nodes.values():
@@ -314,98 +701,134 @@ def build_law_graph_export_rows(
         elif not _clean_str(node.get("root_law_name")):
             node["root_law_name"] = node["law_name"]
 
-    has_child_law_edges = _build_has_child_law_edges(law_nodes)
-    delegates_to_law_edges = _build_delegates_to_law_edges(law_nodes=law_nodes, article_nodes=article_nodes)
+    family_index = _build_family_index(law_nodes)
+    family_laws_by_root_uid = {
+        root_uid: [
+            {
+                "law_name": node.get("law_name"),
+                "classified_level": node.get("classified_level"),
+                "kind_name": node.get("kind_name"),
+            }
+            for node in family.get("nodes", [])
+        ]
+        for root_uid, family in family_index.items()
+    }
+    law_name_index = _build_law_name_index(law_nodes)
 
-    for row in _iter_jsonl(legal_relations_path):
-        if str(row.get("relation_model") or "").strip() != "law_to_law":
+    has_child_law_edges = _build_has_child_law_edges(family_index)
+    delegates_to_law_edges = _build_delegates_to_law_edges(
+        law_nodes=law_nodes,
+        article_nodes=article_nodes,
+        family_index=family_index,
+    )
+
+    for article in article_nodes.values():
+        source_law_uid = str(article.get("law_uid") or "").strip()
+        source_article_uid = str(article.get("article_uid") or "").strip()
+        source_article_key = str(article.get("article_key") or "").strip()
+        root_law_uid = str(article.get("root_law_uid") or "").strip()
+        source_law_name = _clean_str(article.get("law_name"))
+        source_article_no_display = _clean_str(article.get("article_no_display"))
+        text = str(article.get("text") or "")
+        if not source_law_uid or not source_article_uid or not source_article_key or not root_law_uid or not source_law_name or not text:
             continue
-        if str(row.get("resolution_status") or "").strip() == "unresolved_external":
-            continue
 
-        source_law_uid = str(row.get("source_law_uid") or "").strip()
-        target_law_uid = str(row.get("law_uid") or "").strip()
-        relation_type = str(row.get("relation_type") or "").strip()
-        relation_types = list(row.get("relation_types") or [])
-        source_article_key = str(row.get("source_article_key") or "").strip()
-        source_article_uid = _article_uid(source_law_uid, source_article_key)
+        parsed_references = parse_law_article_references(
+            text,
+            source_law_name=source_law_name,
+            source_law_level=article.get("classified_level"),
+            source_article_key=source_article_key,
+            article_order=article_orders_by_law.get(source_law_uid, []),
+            root_law_name=_clean_str(article.get("root_law_name")) or source_law_name,
+            family_laws=family_laws_by_root_uid.get(root_law_uid, []),
+        )
 
-        if relation_type == "cited_law" and source_law_uid and target_law_uid:
-            if source_law_uid not in law_nodes or target_law_uid not in law_nodes:
+        for reference in parsed_references:
+            target_node = _resolve_target_law_node(reference, law_name_index=law_name_index)
+            if target_node is None:
                 continue
-            edge_key = _edge_id("REFERS_TO_LAW", source_law_uid, target_law_uid)
-            current = refers_to_law_edges.get(edge_key)
-            if current is None:
-                refers_to_law_edges[edge_key] = {
-                    "edge_id": edge_key,
-                    "edge_type": "REFERS_TO_LAW",
-                    "source_law_uid": source_law_uid,
-                    "target_law_uid": target_law_uid,
-                    "relation_type": relation_type,
-                    "relation_types": relation_types,
-                    "resolution_status": row.get("resolution_status"),
-                    "relation_confidence": row.get("relation_confidence"),
-                    "reference_texts": list(row.get("reference_texts") or []),
-                    "source_article_key": row.get("source_article_key"),
-                    "source_article_no_display": row.get("source_article_no_display"),
-                }
-            else:
-                current["relation_types"] = list(dict.fromkeys(list(current.get("relation_types") or []) + relation_types))
-                current["reference_texts"] = list(
-                    dict.fromkeys(list(current.get("reference_texts") or []) + list(row.get("reference_texts") or []))
-                )
-                current["relation_confidence"] = max(
-                    float(current.get("relation_confidence") or 0),
-                    float(row.get("relation_confidence") or 0),
-                )
 
-        if not source_article_uid or not target_law_uid:
-            continue
-
-        target_article_keys = [str(item).strip() for item in list(row.get("article_keys") or []) if str(item).strip()]
-        if not target_article_keys:
-            continue
-
-        is_same_law = "same_law_reference" in relation_types and source_law_uid == target_law_uid
-        filtered_target_article_keys = list(target_article_keys)
-        if is_same_law:
-            filtered_target_article_keys = [key for key in filtered_target_article_keys if key != source_article_key]
-        if not filtered_target_article_keys:
-            continue
-
-        for target_article_key in filtered_target_article_keys:
-            target_article_uid = _article_uid(target_law_uid, target_article_key)
-            if not target_article_uid:
+            target_law_uid = str(target_node.get("law_uid") or "").strip()
+            if not target_law_uid:
                 continue
-            if source_article_uid not in article_nodes or target_article_uid not in article_nodes:
+
+            relation_confidence = float(reference.get("resolution_confidence") or 0.9)
+            reference_text = _clean_str(reference.get("reference_text")) or source_article_no_display or source_article_key
+            reference_type = str(reference.get("reference_type") or "").strip() or "article_reference"
+            detail_list = _reference_article_details(reference)
+            relation_types = _build_relation_types(
+                base_relation_type="related_law",
+                reference_type=reference_type,
+                source_law_uid=source_law_uid,
+                target_law_uid=target_law_uid,
+            )
+
+            created_article_edge = False
+            for detail in detail_list:
+                target_article_uid = _article_uid(target_law_uid, detail.get("article_key"))
+                if not target_article_uid or target_article_uid not in article_nodes or target_article_uid == source_article_uid:
+                    continue
+                _upsert_refers_to_article_edge(
+                    refers_to_article_edges,
+                    source_article_uid=source_article_uid,
+                    target_article_uid=target_article_uid,
+                    source_law_uid=source_law_uid,
+                    target_law_uid=target_law_uid,
+                    source_article_key=source_article_key,
+                    source_article_no_display=source_article_no_display,
+                    target_detail=detail,
+                    relation_types=relation_types,
+                    relation_confidence=relation_confidence,
+                    reference_text=reference_text,
+                )
+                created_article_edge = True
+
+            if (not detail_list or not created_article_edge) and source_law_uid != target_law_uid:
+                _upsert_refers_to_law_edge(
+                    refers_to_law_edges,
+                    source_law_uid=source_law_uid,
+                    target_law_uid=target_law_uid,
+                    root_law_uid=root_law_uid,
+                    root_law_name=_clean_str(article.get("root_law_name")) or source_law_name,
+                    source_article_key=source_article_key,
+                    source_article_no_display=source_article_no_display,
+                    relation_types=_build_relation_types(
+                        base_relation_type="cited_law",
+                        reference_type=reference_type,
+                        source_law_uid=source_law_uid,
+                        target_law_uid=target_law_uid,
+                    ),
+                    relation_confidence=relation_confidence,
+                    reference_text=reference_text,
+                    target_article_details=detail_list,
+                )
+
+        for mention in _extract_bare_law_mentions(text, law_nodes=law_nodes, parsed_references=parsed_references):
+            target_nodes = list(law_name_index.get(_family_key(mention.get("law_name")) or "", []))
+            if len(target_nodes) != 1:
                 continue
-            edge_key = _edge_id("REFERS_TO_ARTICLE", source_article_uid, target_article_uid)
-            current = refers_to_article_edges.get(edge_key)
-            if current is None:
-                refers_to_article_edges[edge_key] = {
-                    "edge_id": edge_key,
-                    "edge_type": "REFERS_TO_ARTICLE",
-                    "source_article_uid": source_article_uid,
-                    "target_article_uid": target_article_uid,
-                    "source_law_uid": source_law_uid,
-                    "target_law_uid": target_law_uid,
-                    "source_article_key": source_article_key,
-                    "target_article_key": target_article_key,
-                    "relation_type": relation_type,
-                    "relation_types": relation_types,
-                    "resolution_status": row.get("resolution_status"),
-                    "relation_confidence": row.get("relation_confidence"),
-                    "reference_texts": list(row.get("reference_texts") or []),
-                }
-            else:
-                current["relation_types"] = list(dict.fromkeys(list(current.get("relation_types") or []) + relation_types))
-                current["reference_texts"] = list(
-                    dict.fromkeys(list(current.get("reference_texts") or []) + list(row.get("reference_texts") or []))
-                )
-                current["relation_confidence"] = max(
-                    float(current.get("relation_confidence") or 0),
-                    float(row.get("relation_confidence") or 0),
-                )
+            target_law_uid = str(target_nodes[0].get("law_uid") or "").strip()
+            if not target_law_uid or target_law_uid == source_law_uid:
+                continue
+
+            _upsert_refers_to_law_edge(
+                refers_to_law_edges,
+                source_law_uid=source_law_uid,
+                target_law_uid=target_law_uid,
+                root_law_uid=root_law_uid,
+                root_law_name=_clean_str(article.get("root_law_name")) or source_law_name,
+                source_article_key=source_article_key,
+                source_article_no_display=source_article_no_display,
+                relation_types=_build_relation_types(
+                    base_relation_type="cited_law",
+                    reference_type="bare_law_name",
+                    source_law_uid=source_law_uid,
+                    target_law_uid=target_law_uid,
+                ),
+                relation_confidence=float(mention.get("resolution_confidence") or 0.8),
+                reference_text=_clean_str(mention.get("reference_text")) or str(mention.get("law_name") or "").strip(),
+                target_article_details=[],
+            )
 
     return {
         "law_nodes": sorted(law_nodes.values(), key=lambda row: str(row.get("law_uid") or "")),

--- a/apps/backend/legal-pipeline/src/parser/law_reference_parser.py
+++ b/apps/backend/legal-pipeline/src/parser/law_reference_parser.py
@@ -14,19 +14,22 @@ from typing import Any
 
 from src.common.law_meta import normalize_classified_level
 
-ARTICLE_PATTERN = re.compile(r"제\s*(\d+)\s*조(?:\s*의\s*(\d+))?")
+BASE_ARTICLE_REF_PATTERN = r"제\s*(\d+)\s*조(?:\s*의\s*(\d+))?"
+SUBARTICLE_UNIT_BLOCK_PATTERN = r"(?P<unit_block>(?:\s*제\s*\d+\s*(?:항|호|목))*)"
+ARTICLE_PATTERN = re.compile(rf"{BASE_ARTICLE_REF_PATTERN}{SUBARTICLE_UNIT_BLOCK_PATTERN}")
 ARTICLE_RANGE_PATTERN = re.compile(
     r"제\s*(\d+)\s*조(?:\s*의\s*(\d+))?\s*(?:부터|내지)\s*제\s*(\d+)\s*조(?:\s*의\s*(\d+))?\s*(?:까지)?"
 )
 ARTICLE_BLOCK_PATTERN = (
-    r"제\s*\d+\s*조(?:\s*의\s*\d+)?"
+    r"제\s*\d+\s*조(?:\s*의\s*\d+)?(?:\s*제\s*\d+\s*(?:항|호|목))*"
     r"(?:\s*(?:부터|내지)\s*제\s*\d+\s*조(?:\s*의\s*\d+)?\s*(?:까지)?)?"
-    r"(?:\s*(?:,|및|와|과|또는|혹은|·)\s*제\s*\d+\s*조(?:\s*의\s*\d+)?)*"
+    r"(?:\s*(?:,|및|와|과|또는|혹은|·)\s*제\s*\d+\s*조(?:\s*의\s*\d+)?(?:\s*제\s*\d+\s*(?:항|호|목))*)*"
 )
 SINGLE_ARTICLE_BLOCK_PATTERN = (
-    r"제\s*\d+\s*조(?:\s*의\s*\d+)?"
+    r"제\s*\d+\s*조(?:\s*의\s*\d+)?(?:\s*제\s*\d+\s*(?:항|호|목))*"
     r"(?:\s*(?:부터|내지)\s*제\s*\d+\s*조(?:\s*의\s*\d+)?\s*(?:까지)?)?"
 )
+SUBARTICLE_UNIT_PATTERN = re.compile(r"제\s*(\d+)\s*(항|호|목)")
 LAW_NAME_TOKEN_PATTERN = r"(?!및\b|또는\b|혹은\b|와\b|과\b|전조\b|동조\b|같은\b|이\b)[가-힣0-9·ㆍ()]+"
 EXPLICIT_LAW_WITH_ARTICLE_PATTERN = re.compile(
     rf"(?<![가-힣0-9])(?P<law_name>{LAW_NAME_TOKEN_PATTERN}(?:\s+{LAW_NAME_TOKEN_PATTERN}){{0,7}})\s*(?P<article_block>{ARTICLE_BLOCK_PATTERN})"
@@ -119,16 +122,39 @@ def _infer_scope_from_noisy_candidate(text: str) -> str | None:
     return None
 
 
-def _article_ref(main_no: str, branch_no: str | None) -> dict[str, str]:
+def _extract_subarticle_units(unit_block: str | None) -> dict[str, str | None]:
+    paragraph_no: str | None = None
+    item_no: str | None = None
+    subitem_no: str | None = None
+
+    for match in SUBARTICLE_UNIT_PATTERN.finditer(str(unit_block or "")):
+        number = str(int(match.group(1)))
+        unit = match.group(2)
+        if unit == "항" and paragraph_no is None:
+            paragraph_no = number
+        elif unit == "호" and item_no is None:
+            item_no = number
+        elif unit == "목" and subitem_no is None:
+            subitem_no = number
+
+    return {
+        "paragraph_no": paragraph_no,
+        "item_no": item_no,
+        "subitem_no": subitem_no,
+    }
+
+
+def _article_ref(main_no: str, branch_no: str | None, unit_block: str | None = None) -> dict[str, str | None]:
     article_key = str(int(main_no)) if not branch_no else f"{int(main_no)}-{int(branch_no)}"
     article_no_display = f"제{int(main_no)}조" if not branch_no else f"제{int(main_no)}조의{int(branch_no)}"
     return {
         "article_key": article_key,
         "article_no_display": article_no_display,
+        **_extract_subarticle_units(unit_block),
     }
 
 
-def _expand_article_range(start: tuple[str, str | None], end: tuple[str, str | None]) -> list[dict[str, str]]:
+def _expand_article_range(start: tuple[str, str | None], end: tuple[str, str | None]) -> list[dict[str, str | None]]:
     start_main, start_branch = start
     end_main, end_branch = end
     if start_branch is None and end_branch is None:
@@ -144,25 +170,38 @@ def _expand_article_range(start: tuple[str, str | None], end: tuple[str, str | N
     return [_article_ref(start_main, start_branch), _article_ref(end_main, end_branch)]
 
 
-def extract_article_refs(article_block: str) -> list[dict[str, str]]:
-    refs: list[dict[str, str]] = []
+def extract_article_refs(article_block: str) -> list[dict[str, str | None]]:
+    refs: list[dict[str, str | None]] = []
     seen: set[str] = set()
 
     for match in ARTICLE_RANGE_PATTERN.finditer(article_block):
         for article in _expand_article_range(match.group(1, 2), match.group(3, 4)):
-            if article["article_key"] in seen:
+            signature = _article_ref_signature(article)
+            if signature in seen:
                 continue
-            seen.add(article["article_key"])
+            seen.add(signature)
             refs.append(article)
 
     for match in ARTICLE_PATTERN.finditer(article_block):
-        article = _article_ref(match.group(1), match.group(2))
-        if article["article_key"] in seen:
+        article = _article_ref(match.group(1), match.group(2), match.group("unit_block"))
+        signature = _article_ref_signature(article)
+        if signature in seen:
             continue
-        seen.add(article["article_key"])
+        seen.add(signature)
         refs.append(article)
 
     return refs
+
+
+def _article_ref_signature(article_ref: dict[str, str | None]) -> str:
+    return "::".join(
+        [
+            str(article_ref.get("article_key") or "").strip(),
+            str(article_ref.get("paragraph_no") or "").strip(),
+            str(article_ref.get("item_no") or "").strip(),
+            str(article_ref.get("subitem_no") or "").strip(),
+        ]
+    )
 
 
 def _mask_span(text: str, start: int, end: int) -> str:
@@ -325,10 +364,20 @@ def _append_reference(
 ) -> None:
     article_keys = [item["article_key"] for item in article_refs]
     article_no_displays = [item["article_no_display"] for item in article_refs]
+    article_ref_details = [
+        {
+            "article_key": item["article_key"],
+            "article_no_display": item["article_no_display"],
+            "paragraph_no": item.get("paragraph_no"),
+            "item_no": item.get("item_no"),
+            "subitem_no": item.get("subitem_no"),
+        }
+        for item in article_refs
+    ]
     dedup_key = (
         reference_type,
         str(target_law_name or "").strip(),
-        "|".join(article_keys) or _normalize_space(reference_text),
+        "|".join(_article_ref_signature(item) for item in article_refs) or _normalize_space(reference_text),
     )
     if dedup_key in seen:
         return
@@ -341,6 +390,7 @@ def _append_reference(
             "related_law_names": list(dict.fromkeys([name for name in related_law_names or [] if str(name).strip()])),
             "target_article_keys": article_keys,
             "target_article_no_displays": article_no_displays,
+            "target_article_ref_details": article_ref_details,
             "resolution_status": resolution_status,
             "resolution_confidence": resolution_confidence,
         }

--- a/apps/backend/legal-pipeline/tests/test_law_graph_exporter.py
+++ b/apps/backend/legal-pipeline/tests/test_law_graph_exporter.py
@@ -1,8 +1,8 @@
-from src.common.io_utils import _write_json, write_jsonl
+from src.common.io_utils import write_jsonl
 from src.export.law_graph_exporter import build_law_graph_export_rows, write_law_graph_export
 
 
-def test_build_law_graph_export_rows_dedupes_article_nodes_and_splits_edges(tmp_path):
+def test_build_law_graph_export_rows_dedupes_article_nodes_and_builds_reference_edges_from_corpus(tmp_path):
     corpus_path = tmp_path / "dataset" / "legal_corpus.jsonl"
     relations_path = tmp_path / "dataset" / "legal_relations.jsonl"
 
@@ -25,7 +25,7 @@ def test_build_law_graph_export_rows_dedupes_article_nodes_and_splits_edges(tmp_
                 "article_no_display": "제10조",
                 "text": "짧은 본문",
                 "display_text": "짧은 본문",
-                "source_file_path": "a.json",
+                "source_file_path": "root.json",
             },
             {
                 "id": "law::001::article::10::1",
@@ -42,9 +42,9 @@ def test_build_law_graph_export_rows_dedupes_article_nodes_and_splits_edges(tmp_
                 "mst": "100",
                 "article_key": "10",
                 "article_no_display": "제10조",
-                "text": "더 긴 본문 텍스트",
-                "display_text": "더 긴 본문",
-                "source_file_path": "a.json",
+                "text": "제7조 및 근로기준법 시행령에 따른다.",
+                "display_text": "제7조 및 근로기준법 시행령에 따른다.",
+                "source_file_path": "root.json",
             },
             {
                 "id": "law::001::article::7::0",
@@ -60,7 +60,7 @@ def test_build_law_graph_export_rows_dedupes_article_nodes_and_splits_edges(tmp_
                 "article_no_display": "제7조",
                 "text": "제7조 본문",
                 "display_text": "제7조 본문",
-                "source_file_path": "a.json",
+                "source_file_path": "root.json",
             },
             {
                 "id": "law::002::article::1::0",
@@ -76,58 +76,12 @@ def test_build_law_graph_export_rows_dedupes_article_nodes_and_splits_edges(tmp_
                 "article_no_display": "제1조",
                 "text": "시행령 본문",
                 "display_text": "시행령 본문",
-                "source_file_path": "b.json",
+                "source_file_path": "decree.json",
             },
         ],
         corpus_path,
     )
-
-    write_jsonl(
-        [
-            {
-                "id": "relation::law::001::001::10",
-                "relation_model": "law_to_law",
-                "relation_type": "related_law",
-                "relation_types": ["related_law", "same_law_reference"],
-                "resolution_status": "resolved",
-                "relation_confidence": 0.95,
-                "source_law_uid": "001",
-                "law_uid": "001",
-                "source_article_key": "10",
-                "source_article_no_display": "제10조",
-                "article_keys": ["10", "7"],
-                "reference_texts": ["제10조", "제7조"],
-            },
-            {
-                "id": "relation::law::002::001::1",
-                "relation_model": "law_to_law",
-                "relation_type": "cited_law",
-                "relation_types": ["cited_law"],
-                "resolution_status": "resolved",
-                "relation_confidence": 0.8,
-                "source_law_uid": "002",
-                "law_uid": "001",
-                "source_article_key": "1",
-                "source_article_no_display": "제1조",
-                "article_keys": [],
-                "reference_texts": ["근로기준법"],
-            },
-            {
-                "id": "relation::law::002::external::x::1",
-                "relation_model": "law_to_law",
-                "relation_type": "related_law",
-                "relation_types": ["related_law", "external_reference"],
-                "resolution_status": "unresolved_external",
-                "relation_confidence": 0.45,
-                "source_law_uid": "002",
-                "law_uid": None,
-                "source_article_key": "1",
-                "article_keys": ["99"],
-                "reference_texts": ["외부 법령 제99조"],
-            },
-        ],
-        relations_path,
-    )
+    write_jsonl([], relations_path)
 
     rows = build_law_graph_export_rows(
         legal_corpus_path=corpus_path,
@@ -143,15 +97,16 @@ def test_build_law_graph_export_rows_dedupes_article_nodes_and_splits_edges(tmp_
     assert len(rows["refers_to_article_edges"]) == 1
 
     article = next(row for row in rows["article_nodes"] if row["article_uid"] == "article::001::10")
-    assert article["text"] == "더 긴 본문 텍스트"
+    assert article["text"] == "제7조 및 근로기준법 시행령에 따른다."
 
-    edge = rows["refers_to_article_edges"][0]
-    assert edge["source_article_uid"] == "article::001::10"
-    assert edge["target_article_uid"] == "article::001::7"
+    article_edge = rows["refers_to_article_edges"][0]
+    assert article_edge["source_article_uid"] == "article::001::10"
+    assert article_edge["target_article_uid"] == "article::001::7"
 
-    hierarchy_edge = rows["has_child_law_edges"][0]
-    assert hierarchy_edge["source_law_uid"] == "001"
-    assert hierarchy_edge["target_law_uid"] == "002"
+    law_edge = rows["refers_to_law_edges"][0]
+    assert law_edge["source_law_uid"] == "001"
+    assert law_edge["target_law_uid"] == "002"
+    assert "explicit_law_name" in law_edge["relation_types"]
 
 
 def test_build_law_graph_export_rows_skips_blank_law_name_and_restores_root_law_name(tmp_path):
@@ -232,7 +187,7 @@ def test_build_law_graph_export_rows_skips_blank_law_name_and_restores_root_law_
     assert child_article["root_law_name"] == "남녀고용평등과 일ㆍ가정 양립 지원에 관한 법률"
 
 
-def test_build_law_graph_export_rows_builds_family_hierarchy(tmp_path):
+def test_build_law_graph_export_rows_builds_family_hierarchy_without_cross_branch_pairing(tmp_path):
     corpus_path = tmp_path / "dataset" / "legal_corpus.jsonl"
     relations_path = tmp_path / "dataset" / "legal_relations.jsonl"
 
@@ -302,6 +257,22 @@ def test_build_law_graph_export_rows_builds_family_hierarchy(tmp_path):
                 "display_text": "본문",
                 "source_file_path": "other.json",
             },
+            {
+                "id": "law::005::article::1::0",
+                "doc_type": "law",
+                "section_type": "article",
+                "law_uid": "005",
+                "law_name": "근로감독관증 규칙",
+                "root_law_uid": "001",
+                "root_law_name": "근로기준법",
+                "classified_level": "기타",
+                "kind_name": "규칙",
+                "article_key": "1",
+                "article_no_display": "제1조",
+                "text": "본문",
+                "display_text": "본문",
+                "source_file_path": "other-rule.json",
+            },
         ],
         corpus_path,
     )
@@ -330,6 +301,14 @@ def test_build_law_graph_export_rows_builds_family_hierarchy(tmp_path):
             "root_law_name": "근로기준법",
         },
         {
+            "edge_id": "HAS_CHILD_LAW::001::005",
+            "edge_type": "HAS_CHILD_LAW",
+            "source_law_uid": "001",
+            "target_law_uid": "005",
+            "root_law_uid": "001",
+            "root_law_name": "근로기준법",
+        },
+        {
             "edge_id": "HAS_CHILD_LAW::002::003",
             "edge_type": "HAS_CHILD_LAW",
             "source_law_uid": "002",
@@ -340,7 +319,7 @@ def test_build_law_graph_export_rows_builds_family_hierarchy(tmp_path):
     ]
 
 
-def test_build_law_graph_export_rows_builds_delegation_edges(tmp_path):
+def test_build_law_graph_export_rows_builds_delegation_edges_with_branch_matching(tmp_path):
     corpus_path = tmp_path / "dataset" / "legal_corpus.jsonl"
     relations_path = tmp_path / "dataset" / "legal_relations.jsonl"
 
@@ -394,6 +373,22 @@ def test_build_law_graph_export_rows_builds_delegation_edges(tmp_path):
                 "display_text": "시행규칙 본문",
                 "source_file_path": "rule.json",
             },
+            {
+                "id": "law::004::article::1::0",
+                "doc_type": "law",
+                "section_type": "article",
+                "law_uid": "004",
+                "law_name": "근로감독관증 규칙",
+                "root_law_uid": "001",
+                "root_law_name": "근로기준법",
+                "classified_level": "기타",
+                "kind_name": "규칙",
+                "article_key": "1",
+                "article_no_display": "제1조",
+                "text": "다른 규칙 본문",
+                "display_text": "다른 규칙 본문",
+                "source_file_path": "other-rule.json",
+            },
         ],
         corpus_path,
     )
@@ -433,6 +428,152 @@ def test_build_law_graph_export_rows_builds_delegation_edges(tmp_path):
             "source_article_no_displays": ["제2조"],
             "reference_texts": ["제2조"],
         },
+    ]
+
+
+def test_build_law_graph_export_rows_uses_corpus_article_refs_and_preserves_paragraph_metadata(tmp_path):
+    corpus_path = tmp_path / "dataset" / "legal_corpus.jsonl"
+    relations_path = tmp_path / "dataset" / "legal_relations.jsonl"
+
+    write_jsonl(
+        [
+            {
+                "id": "law::001::article::7::0",
+                "doc_type": "law",
+                "section_type": "article",
+                "law_uid": "001",
+                "law_name": "근로기준법",
+                "root_law_uid": "001",
+                "root_law_name": "근로기준법",
+                "classified_level": "법",
+                "kind_name": "법률",
+                "article_key": "7",
+                "article_no_display": "제7조",
+                "text": "제7조 본문",
+                "display_text": "제7조 본문",
+                "source_file_path": "law.json",
+            },
+            {
+                "id": "law::001::article::10::0",
+                "doc_type": "law",
+                "section_type": "article",
+                "law_uid": "001",
+                "law_name": "근로기준법",
+                "root_law_uid": "001",
+                "root_law_name": "근로기준법",
+                "classified_level": "법",
+                "kind_name": "법률",
+                "article_key": "10",
+                "article_no_display": "제10조",
+                "text": "같은 법 제7조제3항에 따른다.",
+                "display_text": "같은 법 제7조제3항에 따른다.",
+                "source_file_path": "law.json",
+            },
+        ],
+        corpus_path,
+    )
+    write_jsonl([], relations_path)
+
+    rows = build_law_graph_export_rows(
+        legal_corpus_path=corpus_path,
+        legal_relations_path=relations_path,
+    )
+
+    assert rows["refers_to_law_edges"] == []
+    assert rows["refers_to_article_edges"] == [
+        {
+            "edge_id": "REFERS_TO_ARTICLE::article::001::10::article::001::7",
+            "edge_type": "REFERS_TO_ARTICLE",
+            "source_article_uid": "article::001::10",
+            "target_article_uid": "article::001::7",
+            "source_law_uid": "001",
+            "target_law_uid": "001",
+            "source_article_key": "10",
+            "source_article_no_display": "제10조",
+            "target_article_key": "7",
+            "target_article_no_display": "제7조",
+            "relation_type": "related_law",
+            "relation_types": ["related_law", "relative_scope", "same_law_reference", "relative_reference"],
+            "resolution_status": "resolved",
+            "relation_confidence": 0.9,
+            "target_paragraph_nos": ["3"],
+            "target_item_nos": [],
+            "target_subitem_nos": [],
+            "reference_texts": ["같은 법 제7조제3항"],
+        }
+    ]
+
+
+def test_build_law_graph_export_rows_falls_back_to_law_edge_when_target_article_is_missing(tmp_path):
+    corpus_path = tmp_path / "dataset" / "legal_corpus.jsonl"
+    relations_path = tmp_path / "dataset" / "legal_relations.jsonl"
+
+    write_jsonl(
+        [
+            {
+                "id": "law::001::article::10::0",
+                "doc_type": "law",
+                "section_type": "article",
+                "law_uid": "001",
+                "law_name": "근로기준법",
+                "root_law_uid": "001",
+                "root_law_name": "근로기준법",
+                "classified_level": "법",
+                "kind_name": "법률",
+                "article_key": "10",
+                "article_no_display": "제10조",
+                "text": "근로기준법 시행령 제99조제2항에 따른다.",
+                "display_text": "근로기준법 시행령 제99조제2항에 따른다.",
+                "source_file_path": "law.json",
+            },
+            {
+                "id": "law::002::article::1::0",
+                "doc_type": "law",
+                "section_type": "article",
+                "law_uid": "002",
+                "law_name": "근로기준법 시행령",
+                "root_law_uid": "001",
+                "root_law_name": "근로기준법",
+                "classified_level": "시행령",
+                "kind_name": "대통령령",
+                "article_key": "1",
+                "article_no_display": "제1조",
+                "text": "시행령 본문",
+                "display_text": "시행령 본문",
+                "source_file_path": "decree.json",
+            },
+        ],
+        corpus_path,
+    )
+    write_jsonl([], relations_path)
+
+    rows = build_law_graph_export_rows(
+        legal_corpus_path=corpus_path,
+        legal_relations_path=relations_path,
+    )
+
+    assert rows["refers_to_article_edges"] == []
+    assert rows["refers_to_law_edges"] == [
+        {
+            "edge_id": "REFERS_TO_LAW::001::002",
+            "edge_type": "REFERS_TO_LAW",
+            "source_law_uid": "001",
+            "target_law_uid": "002",
+            "root_law_uid": "001",
+            "root_law_name": "근로기준법",
+            "relation_type": "cited_law",
+            "relation_types": ["cited_law", "explicit_law_article"],
+            "resolution_status": "resolved",
+            "relation_confidence": 0.95,
+            "source_article_keys": ["10"],
+            "source_article_no_displays": ["제10조"],
+            "target_article_keys": ["99"],
+            "target_article_no_displays": ["제99조"],
+            "target_paragraph_nos": ["2"],
+            "target_item_nos": [],
+            "target_subitem_nos": [],
+            "reference_texts": ["근로기준법 시행령 제99조제2항"],
+        }
     ]
 
 

--- a/apps/backend/legal-pipeline/tests/test_law_reference_parser.py
+++ b/apps/backend/legal-pipeline/tests/test_law_reference_parser.py
@@ -133,3 +133,29 @@ def test_parse_law_article_references_resolves_dongbeop_scope_refs():
     assert relative_scope["target_law_name"] == "건설산업기본법"
     assert relative_scope["target_article_keys"] == ["24"]
     assert relative_scope["resolution_status"] == "resolved"
+
+
+def test_parse_law_article_references_preserves_sub_article_metadata():
+    refs = parse_law_article_references(
+        "제12조제3항제2호에 따른다.",
+        source_law_name="근로기준법",
+        source_law_level="법",
+        source_article_key="4",
+        article_order=ARTICLE_ORDER,
+        root_law_name="근로기준법",
+        family_laws=FAMILY_LAWS,
+    )
+
+    assert len(refs) == 1
+    ref = refs[0]
+    assert ref["reference_type"] == "same_law_article"
+    assert ref["target_article_keys"] == ["12"]
+    assert ref["target_article_ref_details"] == [
+        {
+            "article_key": "12",
+            "article_no_display": "제12조",
+            "paragraph_no": "3",
+            "item_no": "2",
+            "subitem_no": None,
+        }
+    ]


### PR DESCRIPTION
## Work Description
- HAS_CHILD_LAW, DELEGATES_TO_LAW를 family 내부 branch 기준으로 다시 매칭
- REFERS_TO_LAW, REFERS_TO_ARTICLE를 legal_relations.jsonl이 아니라 legal_corpus.jsonl article text
  기준으로 재생성
- 제12조제3항, 제12조제3항제2호 같은 참조를 Article 노드는 유지한 채 edge metadata로 보존
 
## Changes
### 하위 법령 연결 기준 보정
아래처럼 직접 대응하는 경우만 연결
- 법 -> 시행령
- 시행령 -> 시행규칙
- 대응 시행령이 없을 때만 법 -> 시행규칙 fallback

### citation 생성 기준 변경
기존 citation edge는 legal_relations.jsonl(관계 추출 전처리) 결과 기반
=> legal_corpus.jsonl의 article 본문을 직접 파싱
  - REFERS_TO_LAW
  - REFERS_TO_ARTICLE
법령명만 직접 등장하는 경우도 REFERS_TO_LAW로 반영했다.

### 조/항/호 metadata 보존
제12조제3항, 제12조의2제1항, 제12조제3항제2호를 파싱 확장
그래프 모델은 유지
- 노드: Law, Article
- 세부 단위: edge metadata (target_paragraph_nos, target_item_nos, target_subitem_nos)

## Testing
- [ ] 로컬 테스트 완료
- [ ] 기능 동작 확인

## Related Issue
close #100 
