### PR TITLE
[Feature] law_filter 기능 구현 및 응답 흐름 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ reference-docs/
 .claude/
 .codex/
 .codex
+
+# 개인 Claude 지침 문서
+CLAUDE.md
 results/
 
 # Byte-compiled / optimized / DLL files

--- a/apps/backend/api/src/routers/qa.py
+++ b/apps/backend/api/src/routers/qa.py
@@ -39,7 +39,7 @@ class AskRequest(BaseModel):
     question: str = Field(min_length=1, max_length=2000)
     session_id: str | None = None
     doc_types: list[str] | None = None
-    law_names: list[str] | None = None
+    law_filter: list[str] | None = None
 
     @field_validator("question")
     @classmethod
@@ -183,10 +183,10 @@ def ask(
             law_context_status="irrelevant",
         )
 
-    # 사용자가 명시한 law_names 우선, 없으면 파서 결과 사용
+    # UI 법령 필터 우선, 없으면 파서 결과 사용
     effective_law_names = (
-        request.law_names
-        if request.law_names is not None
+        request.law_filter
+        if request.law_filter is not None
         else (parsed.law_names or None)
     )
 
@@ -244,9 +244,10 @@ def ask_stream(
             yield f"data: {json.dumps({'type': 'done', 'retrieved_docs': [], 'law_context_status': 'irrelevant'}, ensure_ascii=False)}\n\n"
         return StreamingResponse(_irrelevant(), media_type="text/event-stream", headers={"X-Accel-Buffering": "no"})
 
+    # UI 법령 필터 우선, 없으면 파서 결과 사용
     effective_law_names = (
-        request.law_names
-        if request.law_names is not None
+        request.law_filter
+        if request.law_filter is not None
         else (parsed.law_names or None)
     )
 

--- a/apps/backend/rag/rag_pipeline/generation/pipeline.py
+++ b/apps/backend/rag/rag_pipeline/generation/pipeline.py
@@ -24,6 +24,11 @@ from ..retrieval.ranking import apply_law_boost, select_rows_with_law_policy
 from ..retrieval.service import RetrievalConfig
 from .service import GenerationConfig, GenerationService
 
+_NO_RESULT_ANSWER = (
+    "관련 법령·판례 문서를 찾지 못했습니다. "
+    "질문을 더 구체적으로 입력하시거나, 법령 필터가 설정되어 있다면 해제 후 다시 시도해보세요."
+)
+
 DEFAULT_SYSTEM_PROMPT = (
     "당신은 노동법 및 하도급법 전문 법률 Q&A 어시스턴트입니다.\n"
     "주요 대상 법령은 근로기준법, 기간제 및 단시간근로자 보호 등에 관한 법률, "
@@ -55,7 +60,7 @@ class RagResult:
 
     answer: str
     retrieved_docs: list[dict[str, Any]]  # 컨텍스트에 사용된 문서 목록
-    law_context_status: str               # "ok" | "missing" | "supplemented"
+    law_context_status: str               # "ok" | "missing" | "supplemented" | "case_only"
 
 
 # ── 프롬프트 빌더 ─────────────────────────────────────────────────────────────
@@ -76,6 +81,8 @@ def build_user_prompt_with_limit(
         )
     elif law_context_status == "supplemented":
         status_line = "참고: 법령(law) 문서를 보강한 컨텍스트로 답변합니다.\n\n"
+    elif law_context_status == "case_only":
+        status_line = "참고: 현재 검색 결과에 법령 조문이 없고 판례·해석례만 포함되어 있습니다.\n조문 근거 없이 판례 중심으로 답변하세요.\n\n"
 
     prefix = (
         f"{status_line}"
@@ -167,6 +174,9 @@ class RagPipeline:
         if intent == "case_law":
             law_names = None
             enforce = False
+            # 판례 중심 질의 — 법령 조문이 섞이지 않도록 판례류로만 제한
+            if doc_types is None:
+                doc_types = ["prec", "decc", "detc", "expc"]
         elif intent == "mixed":
             enforce = False
         else:
@@ -308,6 +318,9 @@ class RagPipeline:
         llm_rows, context_text, law_context_status, law_context_added = self._retrieve(
             question, doc_types=doc_types, law_names=law_names, intent=intent
         )
+        if not llm_rows:
+            logger.info("run: 검색 결과 0건 — LLM 호출 생략")
+            return self._build_result(_NO_RESULT_ANSWER, [], law_context_status)
         prompt = build_user_prompt_with_limit(
             retrieved_context_text=context_text,
             question=question,
@@ -336,6 +349,10 @@ class RagPipeline:
         llm_rows, context_text, law_context_status, law_context_added = self._retrieve(
             question, doc_types=doc_types, law_names=law_names, intent=intent
         )
+        if not llm_rows:
+            logger.info("stream: 검색 결과 0건 — LLM 호출 생략")
+            meta = self._build_result(_NO_RESULT_ANSWER, [], law_context_status)
+            return meta, iter([_NO_RESULT_ANSWER])
         prompt = build_user_prompt_with_limit(
             retrieved_context_text=context_text,
             question=question,

--- a/apps/backend/rag/rag_pipeline/query_parser/data/few_shot.py
+++ b/apps/backend/rag/rag_pipeline/query_parser/data/few_shot.py
@@ -12,10 +12,19 @@ from __future__ import annotations
 # (query, JSON 출력 문자열) 형태로 정의
 # 출처: eval_set.csv 선별 + 무관 질문 직접 작성
 FEW_SHOT_EXAMPLES: list[tuple[str, str]] = [
-    # ── normative ────────────────────────────────────────────────────────────
+    # ── normative: 법령명 명시 ────────────────────────────────────────────────
     (
-        "하도급 대금 지급 기한을 어기면 어떤 불이익이 있나요",
+        "하도급거래 공정화에 관한 법률상 대금 지급 기한을 어기면 어떤 불이익이 있나요",
         '{"law_names": ["하도급거래 공정화에 관한 법률"], "article_no": "제13조", "intent": "normative", "is_legal": true}',
+    ),
+    # ── normative: 법령명 미명시 → [] ────────────────────────────────────────
+    (
+        "연장근로 허용 한도가 어떻게 되나요",
+        '{"law_names": [], "article_no": "", "intent": "normative", "is_legal": true}',
+    ),
+    (
+        "직원 해고 시 사전 통보 기간은 어떻게 되나요",
+        '{"law_names": [], "article_no": "", "intent": "normative", "is_legal": true}',
     ),
     # ── case_law ─────────────────────────────────────────────────────────────
     (
@@ -24,8 +33,8 @@ FEW_SHOT_EXAMPLES: list[tuple[str, str]] = [
     ),
     # ── mixed ────────────────────────────────────────────────────────────────
     (
-        "연장근로 수당 관련 분쟁 판례나 해석 사례가 있나요",
-        '{"law_names": ["근로기준법"], "article_no": "제53조", "intent": "mixed", "is_legal": true}',
+        "근로기준법상 연장근로 수당 관련 판례가 있나요",
+        '{"law_names": ["근로기준법"], "article_no": "", "intent": "mixed", "is_legal": true}',
     ),
     # ── irrelevant ───────────────────────────────────────────────────────────
     (

--- a/apps/backend/rag/rag_pipeline/query_parser/parser.py
+++ b/apps/backend/rag/rag_pipeline/query_parser/parser.py
@@ -26,7 +26,7 @@ _SYSTEM_PROMPT = """\
 
 {{"law_names": [...], "article_no": "...", "intent": "...", "is_legal": true/false}}
 
-- law_names: 아래 목록 중 질문에 해당하는 법령 정식명칭 (없으면 [])
+- law_names: 질문에 법령명이 명시된 경우만 추출. 추론하거나 유추하지 말 것. 없으면 []
 - article_no: 조문번호 (예: "제17조", 없으면 "")
 - intent: "normative" | "case_law" | "mixed" | null (법률 무관이면 null)
 - is_legal: 법률 관련 질문이면 true, 아니면 false

--- a/apps/backend/rag/rag_pipeline/retrieval/opensearch.py
+++ b/apps/backend/rag/rag_pipeline/retrieval/opensearch.py
@@ -57,7 +57,17 @@ def _build_bm25_query(
     if doc_types:
         filters.append({"terms": {"doc_type": doc_types}})
     if law_names:
-        filters.append({"terms": {"law_name": law_names}})
+        filters.append({
+            "bool": {
+                "should": [
+                    {"terms": {"law_name": law_names}},
+                    {"terms": {"root_law_name": law_names}},
+                    {"terms": {"related_law_name": law_names}},
+                    {"terms": {"related_law_names": law_names}},
+                ],
+                "minimum_should_match": 1,
+            }
+        })
 
     query_obj: dict[str, Any] = {"bool": {"must": must}}
     if filters:

--- a/apps/backend/rag/rag_pipeline/retrieval/qdrant.py
+++ b/apps/backend/rag/rag_pipeline/retrieval/qdrant.py
@@ -42,12 +42,23 @@ def _build_qdrant_filter(
     """doc_type / law_name 필터 조건을 Qdrant payload filter 형식으로 생성한다.
 
     두 조건 모두 없으면 None을 반환 (필터 미적용).
+
+    law_names는 컬렉션 종류에 관계없이 OR 조건으로 적용한다.
+    - law_article: law_name 필드에서 매칭
+    - legal_case / legal_relation: root_law_name, related_law_name, related_law_names 에서 매칭
     """
     must: list[dict[str, Any]] = []
     if doc_types:
         must.append({"key": "doc_type", "match": {"any": doc_types}})
     if law_names:
-        must.append({"key": "law_name", "match": {"any": law_names}})
+        must.append({
+            "should": [
+                {"key": "law_name", "match": {"any": law_names}},
+                {"key": "root_law_name", "match": {"any": law_names}},
+                {"key": "related_law_name", "match": {"any": law_names}},
+                {"key": "related_law_names", "match": {"any": law_names}},
+            ]
+        })
     return {"must": must} if must else None
 
 

--- a/apps/backend/rag/rag_pipeline/retrieval/qdrant.py
+++ b/apps/backend/rag/rag_pipeline/retrieval/qdrant.py
@@ -47,19 +47,17 @@ def _build_qdrant_filter(
     - law_article: law_name 필드에서 매칭
     - legal_case / legal_relation: root_law_name, related_law_name, related_law_names 에서 매칭
     """
-    must: list[dict[str, Any]] = []
+    filt: dict[str, Any] = {}
     if doc_types:
-        must.append({"key": "doc_type", "match": {"any": doc_types}})
+        filt["must"] = [{"key": "doc_type", "match": {"any": doc_types}}]
     if law_names:
-        must.append({
-            "should": [
-                {"key": "law_name", "match": {"any": law_names}},
-                {"key": "root_law_name", "match": {"any": law_names}},
-                {"key": "related_law_name", "match": {"any": law_names}},
-                {"key": "related_law_names", "match": {"any": law_names}},
-            ]
-        })
-    return {"must": must} if must else None
+        filt["should"] = [
+            {"key": "law_name", "match": {"any": law_names}},
+            {"key": "root_law_name", "match": {"any": law_names}},
+            {"key": "related_law_name", "match": {"any": law_names}},
+            {"key": "related_law_names", "match": {"any": law_names}},
+        ]
+    return filt if filt else None
 
 
 def search_qdrant_with_vector(

--- a/apps/backend/rag/rag_pipeline/retrieval/ranking.py
+++ b/apps/backend/rag/rag_pipeline/retrieval/ranking.py
@@ -98,7 +98,7 @@ def select_rows_with_law_policy(
 
     Returns:
         (selected_rows, law_context_status, law_context_added)
-        law_context_status: "ok" | "missing" | "supplemented"
+        law_context_status: "ok" | "missing" | "supplemented" | "case_only"
     """
     selected = list(rows[: max(1, top_k)])
     if min_law_contexts <= 0:
@@ -109,6 +109,9 @@ def select_rows_with_law_policy(
         return rank_rows(selected), "ok", True
 
     if not enforce_min_law_contexts:
+        # 조문 0건이고 판례/해석례만 존재하는 경우
+        if law_count == 0 and len(selected) > 0:
+            return rank_rows(selected), "case_only", False
         return rank_rows(selected), "missing", False
 
     # top_k 바깥에서 law 문서 후보 수집

--- a/apps/backend/rag/rag_pipeline/retrieval/service.py
+++ b/apps/backend/rag/rag_pipeline/retrieval/service.py
@@ -31,7 +31,7 @@ class RetrievalConfig:
     top_k: int = 5
     candidate_k: int = 30
     rrf_k: int = 60
-    timeout: int = 120
+    timeout: int = 60
     auto_law_boost: bool = True
     law_boost_score: float = 0.003
     min_law_contexts: int = 1

--- a/apps/frontend/components/AnswerCard.tsx
+++ b/apps/frontend/components/AnswerCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { FileText, BookOpen, ExternalLink, ThumbsUp, ThumbsDown, ChevronDown } from "lucide-react";
+import { FileText, BookOpen, ExternalLink, ThumbsUp, ThumbsDown, ChevronDown, FilterX } from "lucide-react";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -13,6 +13,8 @@ interface AnswerCardProps {
     citations: { article: string; content: string }[];
     references: string[];
     isIrrelevant?: boolean;
+    lawContextStatus?: string;
+    lawFilterActive?: boolean;
   };
   qaId?: string;
 }
@@ -43,8 +45,32 @@ export function AnswerCard({ data, qaId }: AnswerCardProps) {
       toast.error("피드백 제출에 실패했습니다.");
     }
   };
+  const showFilterHint = data.lawContextStatus === "missing" && data.lawFilterActive;
+
+  const handleClearFilter = () => {
+    try { localStorage.removeItem("las_law_filter"); } catch {}
+    window.dispatchEvent(new Event("las_law_filter_cleared"));
+  };
+
   return (
     <div className="space-y-3">
+      {/* 법령 필터 힌트 */}
+      {showFilterHint && (
+        <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2.5 text-xs text-amber-800">
+          <FilterX className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span>
+            선택한 법령 범위에서 관련 정보를 찾지 못했습니다.{" "}
+            <button
+              type="button"
+              className="underline underline-offset-2 hover:text-amber-900"
+              onClick={handleClearFilter}
+            >
+              필터를 해제
+            </button>
+            하고 다시 질문해보세요.
+          </span>
+        </div>
+      )}
       {/* 답변 요약 */}
       <div className="rounded-lg border border-border bg-card p-4">
         <div className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-primary">
@@ -55,7 +81,7 @@ export function AnswerCard({ data, qaId }: AnswerCardProps) {
       </div>
 
       {/* 근거 조문 */}
-      {!data.isIrrelevant && (
+      {!data.isIrrelevant && data.citations.length > 0 && (
         <Collapsible defaultOpen>
           <div className="rounded-lg border-2 border-legal-citation-border bg-legal-citation p-4">
             <CollapsibleTrigger className="flex w-full items-center justify-between mb-1">

--- a/apps/frontend/components/AnswerCard.tsx
+++ b/apps/frontend/components/AnswerCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { FileText, BookOpen, ExternalLink, ThumbsUp, ThumbsDown, ChevronDown, FilterX } from "lucide-react";
+import { FileText, BookOpen, ExternalLink, ThumbsUp, ThumbsDown, ChevronDown, FilterX, Scale } from "lucide-react";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -46,6 +46,7 @@ export function AnswerCard({ data, qaId }: AnswerCardProps) {
     }
   };
   const showFilterHint = data.lawContextStatus === "missing" && data.lawFilterActive;
+  const showCaseOnlyHint = data.lawContextStatus === "case_only";
 
   const handleClearFilter = () => {
     try { localStorage.removeItem("las_law_filter"); } catch {}
@@ -54,6 +55,14 @@ export function AnswerCard({ data, qaId }: AnswerCardProps) {
 
   return (
     <div className="space-y-3">
+      {/* 판례 전용 안내 */}
+      {showCaseOnlyHint && (
+        <div className="flex items-start gap-2 rounded-lg border border-blue-200 bg-blue-50 px-3 py-2.5 text-xs text-blue-800">
+          <Scale className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span>법령 조문 없이 판례·해석례 기반으로 답변합니다. 조문 근거가 필요하다면 더 구체적으로 질문해보세요.</span>
+        </div>
+      )}
+
       {/* 법령 필터 힌트 */}
       {showFilterHint && (
         <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2.5 text-xs text-amber-800">

--- a/apps/frontend/components/AppSidebar.tsx
+++ b/apps/frontend/components/AppSidebar.tsx
@@ -43,12 +43,23 @@ export function AppSidebar() {
   const { state } = useSidebar();
   const collapsed = state === "collapsed";
   const pathname = usePathname();
-  const [selectedLaws, setSelectedLaws] = useState<string[]>([]);
+  const LAW_FILTER_KEY = "las_law_filter";
+
+  const [selectedLaws, setSelectedLaws] = useState<string[]>(() => {
+    try {
+      const raw = localStorage.getItem(LAW_FILTER_KEY);
+      return raw ? JSON.parse(raw) : [];
+    } catch {
+      return [];
+    }
+  });
 
   const toggleLaw = (law: string) => {
-    setSelectedLaws((prev) =>
-      prev.includes(law) ? prev.filter((l) => l !== law) : [...prev, law]
-    );
+    setSelectedLaws((prev) => {
+      const next = prev.includes(law) ? prev.filter((l) => l !== law) : [...prev, law];
+      try { localStorage.setItem(LAW_FILTER_KEY, JSON.stringify(next)); } catch {}
+      return next;
+    });
   };
 
   return (
@@ -128,7 +139,7 @@ export function AppSidebar() {
               {selectedLaws.length > 0 && (
                 <button
                   type="button"
-                  onClick={() => setSelectedLaws([])}
+                  onClick={() => { setSelectedLaws([]); try { localStorage.removeItem(LAW_FILTER_KEY); } catch {} }}
                   className="ml-auto text-[10px] text-muted-foreground hover:text-foreground underline"
                 >
                   전체 해제

--- a/apps/frontend/components/AppSidebar.tsx
+++ b/apps/frontend/components/AppSidebar.tsx
@@ -45,14 +45,14 @@ export function AppSidebar() {
   const pathname = usePathname();
   const LAW_FILTER_KEY = "las_law_filter";
 
-  const [selectedLaws, setSelectedLaws] = useState<string[]>(() => {
+  const [selectedLaws, setSelectedLaws] = useState<string[]>([]);
+
+  useEffect(() => {
     try {
       const raw = localStorage.getItem(LAW_FILTER_KEY);
-      return raw ? JSON.parse(raw) : [];
-    } catch {
-      return [];
-    }
-  });
+      if (raw) setSelectedLaws(JSON.parse(raw));
+    } catch {}
+  }, []);
 
   useEffect(() => {
     const handler = () => setSelectedLaws([]);

--- a/apps/frontend/components/AppSidebar.tsx
+++ b/apps/frontend/components/AppSidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Scale, FileSearch, FilePen, Clock, Settings, Filter, X } from "lucide-react";
@@ -53,6 +53,12 @@ export function AppSidebar() {
       return [];
     }
   });
+
+  useEffect(() => {
+    const handler = () => setSelectedLaws([]);
+    window.addEventListener("las_law_filter_cleared", handler);
+    return () => window.removeEventListener("las_law_filter_cleared", handler);
+  }, []);
 
   const toggleLaw = (law: string) => {
     setSelectedLaws((prev) => {

--- a/apps/frontend/components/AppSidebar.tsx
+++ b/apps/frontend/components/AppSidebar.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Scale, FileSearch, FilePen, Clock, Settings } from "lucide-react";
+import { Scale, FileSearch, FilePen, Clock, Settings, Filter, X } from "lucide-react";
 import {
   Sidebar,
   SidebarContent,
+  SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
   SidebarHeader,
@@ -14,6 +16,8 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from "@/components/ui/sidebar";
+import { cn } from "@/lib/utils";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 const menuItems = [
   { title: "법령 Q&A", icon: Scale, path: "/" },
@@ -23,10 +27,29 @@ const menuItems = [
   { title: "설정", icon: Settings, path: "/settings" },
 ];
 
+const LAW_OPTIONS = [
+  "근로기준법",
+  "최저임금법",
+  "기간제 및 단시간근로자 보호 등에 관한 법률",
+  "파견근로자보호 등에 관한 법률",
+  "근로자퇴직급여 보장법",
+  "남녀고용평등과 일·가정 양립 지원에 관한 법률",
+  "산업재해보상보험법",
+  "하도급거래 공정화에 관한 법률",
+  "건설산업기본법",
+];
+
 export function AppSidebar() {
   const { state } = useSidebar();
   const collapsed = state === "collapsed";
   const pathname = usePathname();
+  const [selectedLaws, setSelectedLaws] = useState<string[]>([]);
+
+  const toggleLaw = (law: string) => {
+    setSelectedLaws((prev) =>
+      prev.includes(law) ? prev.filter((l) => l !== law) : [...prev, law]
+    );
+  };
 
   return (
     <Sidebar collapsible="icon">
@@ -50,6 +73,7 @@ export function AppSidebar() {
           </div>
         )}
       </SidebarHeader>
+
       <SidebarContent>
         <SidebarGroup>
           <SidebarGroupContent>
@@ -76,6 +100,70 @@ export function AppSidebar() {
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>
+
+      <SidebarFooter className="border-t border-sidebar-border">
+        {collapsed ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div className="flex items-center justify-center py-3 cursor-default">
+                <div className="relative">
+                  <Filter className="h-4 w-4 text-muted-foreground" />
+                  {selectedLaws.length > 0 && (
+                    <span className="absolute -top-1 -right-1 flex h-3 w-3 items-center justify-center rounded-full bg-primary text-[8px] font-bold text-primary-foreground">
+                      {selectedLaws.length}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </TooltipTrigger>
+            <TooltipContent side="right">
+              {selectedLaws.length > 0 ? selectedLaws.join(", ") : "법령 필터 없음"}
+            </TooltipContent>
+          </Tooltip>
+        ) : (
+          <div className="px-3 py-3 space-y-2">
+            <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+              <Filter className="h-3 w-3" />
+              <span>법령 필터</span>
+              {selectedLaws.length > 0 && (
+                <button
+                  type="button"
+                  onClick={() => setSelectedLaws([])}
+                  className="ml-auto text-[10px] text-muted-foreground hover:text-foreground underline"
+                >
+                  전체 해제
+                </button>
+              )}
+            </div>
+
+            <div className="flex flex-wrap gap-1">
+              {LAW_OPTIONS.map((law) => {
+                const selected = selectedLaws.includes(law);
+                return (
+                  <button
+                    key={law}
+                    type="button"
+                    onClick={() => toggleLaw(law)}
+                    className={cn(
+                      "flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] transition-colors",
+                      selected
+                        ? "border-primary bg-primary/10 text-primary font-medium"
+                        : "border-border text-muted-foreground hover:border-primary hover:text-primary"
+                    )}
+                  >
+                    {law}
+                    {selected && <X className="h-2.5 w-2.5" />}
+                  </button>
+                );
+              })}
+            </div>
+
+            {selectedLaws.length === 0 && (
+              <p className="text-[10px] text-muted-foreground/60">미선택 시 전체 법령 검색</p>
+            )}
+          </div>
+        )}
+      </SidebarFooter>
     </Sidebar>
   );
 }

--- a/apps/frontend/components/AppSidebar.tsx
+++ b/apps/frontend/components/AppSidebar.tsx
@@ -119,7 +119,7 @@ export function AppSidebar() {
       </SidebarContent>
 
       <SidebarFooter className="border-t border-sidebar-border">
-        {collapsed ? (
+        {pathname !== "/" ? null : collapsed ? (
           <Tooltip>
             <TooltipTrigger asChild>
               <div className="flex items-center justify-center py-3 cursor-default">

--- a/apps/frontend/components/ChatContainer.tsx
+++ b/apps/frontend/components/ChatContainer.tsx
@@ -93,7 +93,14 @@ export function ChatContainer({ onCitationsChange }: ChatContainerProps) {
 
     console.log("[LAS:QA] 질문 전송:", userQuestion.slice(0, 80));
     try {
-      for await (const event of askStream({ question: userQuestion }, controller.signal)) {
+      let lawNames: string[] | undefined;
+      try {
+        const raw = localStorage.getItem("las_law_filter");
+        const parsed = raw ? JSON.parse(raw) : [];
+        if (Array.isArray(parsed) && parsed.length > 0) lawNames = parsed;
+      } catch {}
+
+      for await (const event of askStream({ question: userQuestion, law_names: lawNames }, controller.signal)) {
         if (event.type === "chunk") {
           setMessages((prev) =>
             prev.map((m) =>

--- a/apps/frontend/components/ChatContainer.tsx
+++ b/apps/frontend/components/ChatContainer.tsx
@@ -93,14 +93,14 @@ export function ChatContainer({ onCitationsChange }: ChatContainerProps) {
 
     console.log("[LAS:QA] 질문 전송:", userQuestion.slice(0, 80));
     try {
-      let lawNames: string[] | undefined;
+      let lawFilter: string[] | undefined;
       try {
         const raw = localStorage.getItem("las_law_filter");
         const parsed = raw ? JSON.parse(raw) : [];
-        if (Array.isArray(parsed) && parsed.length > 0) lawNames = parsed;
+        if (Array.isArray(parsed) && parsed.length > 0) lawFilter = parsed;
       } catch {}
 
-      for await (const event of askStream({ question: userQuestion, law_names: lawNames }, controller.signal)) {
+      for await (const event of askStream({ question: userQuestion, law_filter: lawFilter }, controller.signal)) {
         if (event.type === "chunk") {
           setMessages((prev) =>
             prev.map((m) =>
@@ -186,7 +186,7 @@ export function ChatContainer({ onCitationsChange }: ChatContainerProps) {
                       references: [],
                       isIrrelevant: event.law_context_status === "irrelevant",
                       lawContextStatus: event.law_context_status,
-                      lawFilterActive: !!lawNames,
+                      lawFilterActive: !!lawFilter,
                     },
                   }
                 : m

--- a/apps/frontend/components/ChatContainer.tsx
+++ b/apps/frontend/components/ChatContainer.tsx
@@ -185,6 +185,8 @@ export function ChatContainer({ onCitationsChange }: ChatContainerProps) {
                       citations: parsedCitations,
                       references: [],
                       isIrrelevant: event.law_context_status === "irrelevant",
+                      lawContextStatus: event.law_context_status,
+                      lawFilterActive: !!lawNames,
                     },
                   }
                 : m

--- a/apps/frontend/components/MessageBubble.tsx
+++ b/apps/frontend/components/MessageBubble.tsx
@@ -13,6 +13,8 @@ export interface ChatMessage {
     citations: { article: string; content: string }[];
     references: string[];
     isIrrelevant?: boolean;
+    lawContextStatus?: string;
+    lawFilterActive?: boolean;
   };
 }
 

--- a/apps/frontend/lib/api-client.ts
+++ b/apps/frontend/lib/api-client.ts
@@ -77,7 +77,7 @@ export async function deleteHistoryItems(ids: string[]): Promise<{ deleted: numb
 export interface AskRequest {
   question: string;
   doc_types?: string[];
-  law_names?: string[];
+  law_filter?: string[];
 }
 
 export interface RetrievedDoc {

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@las/tsconfig/react-next.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "strict": false,
     "noImplicitAny": false,
     "paths": {


### PR DESCRIPTION
## Work Description
- 법령 필터(law_filter)를 도입하여 사용자가 특정 법령 기준으로 검색 범위를 제어할 수 있도록 구현했습니다.
- 필터 적용 시 Retrieval, Query Parser, 응답 생성까지 전체 흐름에서 일관되게 반영되도록 구조를 개선했습니다.
- 필터로 인해 결과가 제한되거나 판례 중심 응답이 필요한 경우를 고려하여 UX 및 응답 로직을 함께 보완했습니다.
- Qdrant 필터 구조 오류로 인해 발생하던 hang 문제를 수정하고, 파라미터 명확화를 위해 law_filter로 리네이밍했습니다.
<br>

## Changes
- 법령 필터 기능 추가 및 연동
  - 사이드바에 법령 필터 UI 추가 및 선택값 저장(localStorage)
  - Q&A 요청 시 `law_filter` 파라미터로 전달되도록 연동
  - 메인 화면(`/`)에서만 필터 UI 표시

- Retrieval 및 Query Parser 개선
  - Query Parser가 법령명을 과도하게 유추하지 않도록 수정
  - 법령 필터를 `root/related_law_name` 기반으로 확장 적용
    → 필터 정확도 및 검색 recall 개선

- 필터 적용 시 UX 개선
  - 필터로 인해 결과가 없을 경우 해제 유도 배너 표시
  - 필터 해제 시 UI와 상태 즉시 동기화
  - 근거 조문이 없을 경우 관련 패널 미노출 처리

- 판례 중심 응답 처리 추가
  - 판례 질의 시 법령 조문을 제외하고 판례 중심으로 응답 생성
  - 판례만 존재하는 경우 안내 배너 표시

- Qdrant 필터 구조 및 파라미터 개선
  - 잘못된 필터 구조 수정으로 hang 문제 해결
  - `law_names → law_filter`로 파라미터 명확화
  - Qdrant 타임아웃 120s → 60s로 조정

- 기타 수정
  - localStorage 접근 방식 수정으로 SSR hydration 오류 해결
<br>

## Testing
- [x] 로컬 테스트 완료
- [x] 기능 동작 확인

## Related Issue
close #89
