### PR TITLE
[Refactor] Qdrant colleciton : legal-relation 임시 업데이트

### DIFF
--- a/apps/backend/legal-pipeline/README.md
+++ b/apps/backend/legal-pipeline/README.md
@@ -23,8 +23,8 @@
 - `02_related_legal_docs`: 관련 ~례 후보 수집 + canonical case detail hydrate
 - `03_expanded_related_docs`: 법령↔사례 relation 생성
 - `dataset`: 최종 JSONL 생성
-- `emb/handoff`: 현재 `law_article`, `legal_case` 임베딩 및 적재용 handoff 생성
-- `legal_relation`: dataset/OpenSearch 레이어에는 유지하고 Qdrant 임베딩 대상에서는 제외
+- `emb/handoff`: 기본적으로 `law_article`, `legal_case` 임베딩 및 적재용 handoff 생성
+- `legal_relation`: dataset/OpenSearch에는 유지하고, 필요 시 컬렉션 선택형으로 Qdrant 임베딩/적재 가능
 ---
 
 ## 2. 실행
@@ -32,10 +32,8 @@
 ### 2-1. 요구사항
 
 - Python `==3.13.*`
-- Python `==3.13.*`
 - `uv` 사용 권장
 - `.env` 파일에 `LAW_OC=<국가법령정보 API 키>` 필요
-- 임베딩 생성 시 `OPENAI_API_KEY` 필요
 - 임베딩 생성 시 `OPENAI_API_KEY` 필요
 
 ### 2-2. 설치(프로젝트 루트 기준)
@@ -89,12 +87,11 @@ uv run apps/backend/legal-pipeline/scripts/run_current_law_collection.py --max-r
 현재 정책:
 
 - dataset는 계속 `law_article`, `legal_case`, `legal_relation` 3종을 생성
-- Qdrant용 새 임베딩 생성은 현재 `law_article`, `legal_case`만 대상
-- `legal_relation`은 현재 OpenSearch only 정책으로 유지
-- `legal_relation`은 source/import JSONL은 계속 생성하지만 `.npy` 임베딩은 만들지 않는다
-- 현재 기준 manifest는 OpenAI `text-embedding-3-large`, `1024`차원, `law_article 1982`, `legal_case 73690`이다
+- Qdrant 기본 full 임베딩 생성은 현재 `law_article`, `legal_case`만 대상
+- `legal_relation`은 기본 retrieval 정책상 OpenSearch 중심이지만, 필요 시 `--collection legal_relation`으로 별도 임베딩/적재할 수 있다
+- `qdrant_embedding_manifest.json`은 마지막 임베딩 실행 컬렉션만 기록한다
+- 현재 기준 dataset/handoff 규모는 `law_article 1,982`, `legal_case 73,690`, `legal_relation 18,461`이다
 
-임베딩 backend는 OpenAI-compatible API만 사용한다.
 임베딩 backend는 OpenAI-compatible API만 사용한다.
 
 ```bash
@@ -103,22 +100,25 @@ export OPENAI_API_KEY="<YOUR_OPENAI_API_KEY>"
 # 선택 사항: 기본 차원 대신 축소할 때만 지정
 # export OPENAI_BASE_URL="https://api.openai.com/v1"
 # export OPENAI_EMBEDDING_DIMENSIONS="1024"
-# 선택 사항: 기본 차원 대신 축소할 때만 지정
-# export OPENAI_BASE_URL="https://api.openai.com/v1"
-# export OPENAI_EMBEDDING_DIMENSIONS="1024"
 ```
 
 ### 3-2. Qdrant 임베딩 실행
 
-현재 full embedding 대상:
+현재 기본 full embedding 대상:
 
 - `law_article`
 - `legal_case`
 
-`legal_relation`은 dataset/OpenSearch 산출물에는 남고, 현재는 OpenSearch only로 유지한다. Qdrant 새 임베딩 생성 대상에서는 제외한다.
+`legal_relation`은 dataset/OpenSearch 산출물에는 남고, 기본 full 임베딩 대상에서는 제외한다. 다만 필요 시 별도 실행할 수 있다.
 
 ```bash
 uv run apps/backend/legal-pipeline/scripts/embed_qdrant_3collections.py
+```
+
+`legal_relation`만 별도로 임베딩하려면:
+
+```bash
+uv run apps/backend/legal-pipeline/scripts/embed_qdrant_3collections.py --collection legal_relation
 ```
 
 옵션 예시:
@@ -137,6 +137,7 @@ uv run apps/backend/legal-pipeline/scripts/embed_qdrant_3collections.py \
   - `law_article.body.npy`
   - `law_article.appendix.npy`
   - `legal_case.npy`
+  - `legal_relation.npy` (선택 실행 시)
   - 각 collection별 `*.meta.jsonl`, `*.manifest.json`
 - `data/handoff/qdrant_3collections/source/`
   - source JSONL
@@ -146,8 +147,8 @@ uv run apps/backend/legal-pipeline/scripts/embed_qdrant_3collections.py \
 
 참고:
 
-- 현재 스크립트는 `legal_relation` 임베딩을 만들지 않는다.
-- `legal_relation`은 현재 OpenSearch 적재 대상으로 유지한다.
+- `qdrant_embedding_manifest.json`은 마지막 임베딩 실행 컬렉션만 기록한다.
+- `legal_relation`은 기본 full 임베딩 대상은 아니지만, 선택 실행 시 `.npy`와 import JSONL을 생성한다.
 
 ### 3-4. 현재 운영 기준 명령 순서
 
@@ -160,6 +161,15 @@ uv run --project apps/backend/legal-pipeline python apps/backend/legal-pipeline/
 uv run --project apps/backend/legal-pipeline python apps/backend/legal-pipeline/scripts/upload/load_qdrant.py
 uv run --project apps/backend/legal-pipeline python apps/backend/legal-pipeline/scripts/upload/index_opensearch.py
 uv run --project apps/backend/legal-pipeline python apps/backend/legal-pipeline/scripts/upload/load_opensearch.py
+```
+
+`legal_relation`만 따로 재생성/재적재할 때:
+
+```bash
+uv run --project apps/backend/legal-pipeline python apps/backend/legal-pipeline/scripts/embed_qdrant_3collections.py --collection legal_relation
+uv run --project apps/backend/legal-pipeline python apps/backend/legal-pipeline/scripts/upload/indexing.py --collection legal_relation --recreate
+uv run --project apps/backend/legal-pipeline python apps/backend/legal-pipeline/scripts/upload/load_qdrant.py --collection legal_relation
+uv run --project apps/backend/legal-pipeline python apps/backend/legal-pipeline/scripts/upload/load_opensearch.py --collection legal_relation --recreate-index
 ```
 
 ### 3-5. OpenSearch 인덱스 생성 / 전체 적재
@@ -310,9 +320,11 @@ data/
 │   │   ├── source/
 │   │   │   ├── law_article.jsonl
 │   │   │   ├── legal_case.jsonl
+│   │   │   ├── legal_relation.jsonl            # when selected
 │   │   ├── import/
 │   │   │   ├── law_article_for_import.jsonl
 │   │   │   ├── legal_case_for_import.jsonl
+│   │   │   ├── legal_relation_for_import.jsonl # when selected
 │   │   └── qdrant_embedding_manifest.json
 │   ├── opensearch_bulk/
 │   │   ├── law_article.bulk.ndjson

--- a/apps/backend/legal-pipeline/scripts/embed_qdrant_3collections.py
+++ b/apps/backend/legal-pipeline/scripts/embed_qdrant_3collections.py
@@ -27,7 +27,8 @@ NORMALIZE_EMBEDDINGS = EMBEDDING_SETTINGS.normalize_embeddings
 EMBEDDING_DTYPE = EMBEDDING_SETTINGS.dtype
 DEFAULT_BATCH_SIZE = 128
 CASE_DOC_TYPES = {"prec", "detc", "decc", "expc"}
-COLLECTIONS = ("law_article", "legal_case")
+DEFAULT_COLLECTIONS = ("law_article", "legal_case")
+SUPPORTED_COLLECTIONS = ("law_article", "legal_case", "legal_relation")
 APPENDIX_VECTOR_PLACEHOLDER = "[NO_APPENDIX_LINKED]"
 LAW_ARTICLE_VECTOR_NAMES = ("body", "appendix")
 
@@ -661,9 +662,22 @@ def write_embedding_manifest(
     return manifest_path
 
 
+def _resolve_target_collections(selected: Sequence[str] | None) -> tuple[str, ...]:
+    if not selected:
+        return DEFAULT_COLLECTIONS
+
+    targets: list[str] = []
+    for name in selected:
+        if name not in SUPPORTED_COLLECTIONS:
+            raise ValueError(f"Unsupported collection: {name}")
+        if name not in targets:
+            targets.append(name)
+    return tuple(targets)
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Embed Qdrant handoff files for law_article and legal_case."
+        description="Embed selected Qdrant handoff files."
     )
     parser.add_argument(
         "--dataset-dir",
@@ -689,6 +703,16 @@ def parse_args() -> argparse.Namespace:
         default=DEFAULT_BATCH_SIZE,
         help="Embedding encode batch size.",
     )
+    parser.add_argument(
+        "--collection",
+        action="append",
+        choices=SUPPORTED_COLLECTIONS,
+        default=None,
+        help=(
+            "Target collection to embed. Repeat to select multiple. "
+            "Default: law_article + legal_case"
+        ),
+    )
     return parser.parse_args()
 
 
@@ -699,26 +723,30 @@ def main() -> None:
     emb_dir: Path = args.emb_dir
     handoff_dir: Path = args.handoff_dir
     batch_size: int = args.batch_size
+    target_collections = _resolve_target_collections(args.collection)
 
     if not dataset_dir.exists():
         raise FileNotFoundError(f"dataset_dir not found: {dataset_dir}")
 
     print(f"[embed] model={MODEL_NAME}")
+    print(f"[embed] collections={', '.join(target_collections)}")
 
     model = create_embedding_backend(EMBEDDING_SETTINGS)
 
     try:
         collection_manifests: list[dict] = []
-        collection_manifests.append(
-            embed_law_article(
-                model=model,
-                dataset_dir=dataset_dir,
-                emb_dir=emb_dir,
-                handoff_dir=handoff_dir,
-                batch_size=batch_size,
-            )
-        )
-        for collection_name in ("legal_case",):
+        for collection_name in target_collections:
+            if collection_name == "law_article":
+                collection_manifests.append(
+                    embed_law_article(
+                        model=model,
+                        dataset_dir=dataset_dir,
+                        emb_dir=emb_dir,
+                        handoff_dir=handoff_dir,
+                        batch_size=batch_size,
+                    )
+                )
+                continue
             collection_manifests.append(
                 embed_simple_collection(
                     model=model,

--- a/apps/backend/legal-pipeline/scripts/embed_qdrant_incremental.py
+++ b/apps/backend/legal-pipeline/scripts/embed_qdrant_incremental.py
@@ -15,8 +15,11 @@ from src.common.embedding_backend import create_embedding_backend, load_embeddin
 from src.common.io_utils import _iter_jsonl, _write_json, _write_jsonl
 from scripts.embed_qdrant_3collections import (
     DEFAULT_BATCH_SIZE,
+    DEFAULT_COLLECTIONS,
+    SUPPORTED_COLLECTIONS,
     embed_law_article,
     embed_simple_collection,
+    _resolve_target_collections,
     write_embedding_manifest,
 )
 
@@ -42,23 +45,32 @@ def build_incremental_embeddings(
     handoff_dir: Path,
     delta_batch_id: str,
     batch_size: int,
+    target_collections: tuple[str, ...] = DEFAULT_COLLECTIONS,
 ) -> dict:
     corpus_upserts, corpus_deletes, relation_upserts, relation_deletes = _load_patch_rows(dataset_patch_dir)
     delete_groups: dict[str, list[dict]] = defaultdict(list)
-    embeddable_collections = ("law_article", "legal_case")
+    embeddable_collections = set(target_collections)
     for row in corpus_deletes:
         collection_name = _infer_collection_name(row, relation_file=False)
         if collection_name in embeddable_collections:
             delete_groups[collection_name].append(row)
+    for row in relation_deletes:
+        if "legal_relation" in embeddable_collections:
+            delete_groups["legal_relation"].append(row)
 
-    corpus_embed_upserts = list(corpus_upserts)
+    corpus_embed_upserts = [
+        row
+        for row in corpus_upserts
+        if _infer_collection_name(row, relation_file=False) in embeddable_collections
+    ]
+    relation_embed_upserts = list(relation_upserts) if "legal_relation" in embeddable_collections else []
 
-    if not corpus_embed_upserts:
+    if not corpus_embed_upserts and not relation_embed_upserts:
         emb_dir.mkdir(parents=True, exist_ok=True)
         handoff_dir.mkdir(parents=True, exist_ok=True)
         collection_manifests = [
-            {"collection_name": "law_article", "count": 0, "skipped": True, "reason": "no patch rows"},
-            {"collection_name": "legal_case", "count": 0, "skipped": True, "reason": "no patch rows"},
+            {"collection_name": name, "count": 0, "skipped": True, "reason": "no patch rows"}
+            for name in target_collections
         ]
         write_embedding_manifest(
             handoff_dir=handoff_dir,
@@ -98,13 +110,15 @@ def build_incremental_embeddings(
     with tempfile.TemporaryDirectory(prefix="incremental-dataset-") as tmp_dir:
         tmp_dataset_dir = Path(tmp_dir)
         _write_jsonl(tmp_dataset_dir / "legal_corpus.jsonl", corpus_embed_upserts)
-        _write_jsonl(tmp_dataset_dir / "legal_relations.jsonl", [])
+        _write_jsonl(tmp_dataset_dir / "legal_relations.jsonl", relation_embed_upserts)
 
         model = create_embedding_backend(load_embedding_settings())
         collection_manifests: list[dict] = []
 
         try:
-            if any(str(row.get("doc_type") or "").strip() == "law" for row in corpus_embed_upserts):
+            if "law_article" in embeddable_collections and any(
+                str(row.get("doc_type") or "").strip() == "law" for row in corpus_embed_upserts
+            ):
                 collection_manifests.append(
                     embed_law_article(
                         model=model,
@@ -114,11 +128,13 @@ def build_incremental_embeddings(
                         batch_size=batch_size,
                     )
                 )
-            else:
+            elif "law_article" in embeddable_collections:
                 collection_manifests.append(
                     {"collection_name": "law_article", "count": 0, "skipped": True, "reason": "no patch rows"}
                 )
-            for collection_name in ("legal_case",):
+            for collection_name in target_collections:
+                if collection_name == "law_article":
+                    continue
                 collection_manifests.append(
                     embed_simple_collection(
                         model=model,
@@ -177,6 +193,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--emb-dir", type=Path, default=None)
     parser.add_argument("--handoff-dir", type=Path, default=None)
     parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
+    parser.add_argument(
+        "--collection",
+        action="append",
+        choices=SUPPORTED_COLLECTIONS,
+        default=None,
+        help="Target collection to embed. Repeat to select multiple. Default: law_article + legal_case",
+    )
     return parser.parse_args()
 
 
@@ -184,6 +207,7 @@ def main() -> None:
     args = parse_args()
     emb_dir = args.emb_dir or Path("data/emb/qdrant_incremental") / args.delta_batch_id
     handoff_dir = args.handoff_dir or Path("data/handoff/qdrant_incremental") / args.delta_batch_id
+    target_collections = _resolve_target_collections(args.collection)
 
     manifest = build_incremental_embeddings(
         dataset_patch_dir=args.dataset_patch_dir,
@@ -191,6 +215,7 @@ def main() -> None:
         handoff_dir=handoff_dir,
         delta_batch_id=args.delta_batch_id,
         batch_size=args.batch_size,
+        target_collections=target_collections,
     )
     print(json.dumps(manifest, ensure_ascii=False, indent=2))
 

--- a/apps/backend/legal-pipeline/scripts/upload/load_qdrant_incremental.py
+++ b/apps/backend/legal-pipeline/scripts/upload/load_qdrant_incremental.py
@@ -38,25 +38,33 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Apply incremental Qdrant patch")
     parser.add_argument("--patch-dir", type=Path, required=True, help="handoff incremental patch directory")
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--collection", action="append", default=None, help="특정 컬렉션만 적용. 반복 지정 가능")
     args = parser.parse_args()
 
     patch_dir = args.patch_dir
     manifest = _load_manifest(patch_dir)
     delete_manifest = json.loads((patch_dir / "delete_manifest.json").read_text(encoding="utf-8"))
     client = None if args.dry_run else get_client()
+    selected_collections = set(args.collection or [])
 
     print("=" * 60)
     print("Qdrant incremental patch")
     print(f"  patch_dir: {patch_dir}")
     print(f"  dry_run: {args.dry_run}")
+    if selected_collections:
+        print(f"  collections: {', '.join(sorted(selected_collections))}")
     print("=" * 60)
 
     for collection_name, items in sorted(delete_manifest.get("collections", {}).items()):
+        if selected_collections and collection_name not in selected_collections:
+            continue
         _delete_points(client, collection_name, items, args.dry_run)
 
     for collection in manifest.get("collections", []):
         collection_name = str(collection.get("collection_name") or "").strip()
         if not collection_name:
+            continue
+        if selected_collections and collection_name not in selected_collections:
             continue
         if collection.get("skipped"):
             print(f"  skip upsert: {collection_name}")

--- a/apps/backend/legal-pipeline/tests/test_embed_qdrant_3collections.py
+++ b/apps/backend/legal-pipeline/tests/test_embed_qdrant_3collections.py
@@ -5,6 +5,7 @@ from src.common.io_utils import _write_jsonl
 from scripts.embed_qdrant_3collections import (
     _build_meta,
     _build_retrieval_policy,
+    _resolve_target_collections,
     _scan_collection,
     write_embedding_manifest,
 )
@@ -169,3 +170,15 @@ def test_write_embedding_manifest_uses_collection_dim(tmp_path):
 
     assert payload["model_name"] == "text-embedding-3-large"
     assert payload["embedding_dim"] == 1024
+
+
+def test_resolve_target_collections_defaults_to_primary_collections():
+    assert _resolve_target_collections(None) == ("law_article", "legal_case")
+
+
+def test_resolve_target_collections_supports_opt_in_legal_relation():
+    assert _resolve_target_collections(["legal_relation"]) == ("legal_relation",)
+    assert _resolve_target_collections(["legal_relation", "legal_case", "legal_relation"]) == (
+        "legal_relation",
+        "legal_case",
+    )

--- a/apps/backend/legal-pipeline/tests/test_embed_qdrant_incremental.py
+++ b/apps/backend/legal-pipeline/tests/test_embed_qdrant_incremental.py
@@ -95,3 +95,65 @@ def test_build_incremental_embeddings_ignores_relation_only_patch(tmp_path, monk
     assert [item["collection_name"] for item in manifest["collections"]] == ["law_article", "legal_case"]
     delete_manifest = json.loads((tmp_path / "handoff" / "delete_manifest.json").read_text(encoding="utf-8"))
     assert delete_manifest["collections"] == {}
+
+
+def test_build_incremental_embeddings_supports_relation_only_patch_when_selected(tmp_path, monkeypatch):
+    patch_dir = tmp_path / "patch"
+    _write_jsonl(patch_dir / "legal_corpus.upsert.jsonl", [])
+    _write_jsonl(patch_dir / "legal_corpus.delete.jsonl", [])
+    _write_jsonl(
+        patch_dir / "legal_relations.upsert.jsonl",
+        [
+            {
+                "id": "relation::law::source-law::target-law::16",
+                "canonical_id": "relation::law::source-law::target-law::16",
+                "doc_type": "relation",
+                "relation_model": "law_to_law",
+                "text": "law relation",
+            }
+        ],
+    )
+    _write_jsonl(
+        patch_dir / "legal_relations.delete.jsonl",
+        [
+            {
+                "id": "relation::law::old::target::1",
+                "canonical_id": "relation::law::old::target::1",
+                "_point_id": "relation::law::old::target::1",
+                "doc_type": "relation",
+            }
+        ],
+    )
+
+    class FakeModel:
+        model_name = "fake-model"
+
+        def encode(self, texts, batch_size=0):
+            import numpy as np
+
+            return np.ones((len(texts), 3), dtype=np.float32)
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr("scripts.embed_qdrant_incremental.create_embedding_backend", lambda *_a, **_k: FakeModel())
+
+    manifest = build_incremental_embeddings(
+        dataset_patch_dir=patch_dir,
+        emb_dir=tmp_path / "emb",
+        handoff_dir=tmp_path / "handoff",
+        delta_batch_id="20260414",
+        batch_size=8,
+        target_collections=("legal_relation",),
+    )
+
+    assert [item["collection_name"] for item in manifest["collections"]] == ["legal_relation"]
+    assert manifest["collections"][0]["count"] == 1
+    delete_manifest = json.loads((tmp_path / "handoff" / "delete_manifest.json").read_text(encoding="utf-8"))
+    assert delete_manifest["collections"]["legal_relation"] == [
+        {
+            "id": "relation::law::old::target::1",
+            "canonical_id": "relation::law::old::target::1",
+            "_point_id": "relation::law::old::target::1",
+        }
+    ]


### PR DESCRIPTION
## Work Description
- Qdrant/OpenSearch 검색 결과 불일치 문제 해결

## Changes
- apps/backend/legal-pipeline/README.md
  - 중복 라인, 및 변경 내역 간략 추가
- apps/backend/legal-pipeline/scripts/embed_qdrant_3collections.py
  - --collection legal_relation`으로 별도 임베딩/적재 가능
- apps/backend/legal-pipeline/scripts/upload/load_qdrant_incremental.py
- apps/backend/legal-pipeline/scripts/embed_qdrant_incremental.py
  - 증분 코드도 수정 사항 적용 

## Testing
- law_article
  - handoff 기대값: 1,982
  - import JSONL: 1,982
  - unique _point_id: 1,982
  - Qdrant count: 1,982
  - OpenSearch count: 1,982
- legal_case
  - handoff 기대값: 73,690
  - import JSONL: 73,690
  - unique _point_id: 73,690
  - Qdrant count: 73,690
  - OpenSearch count: 73,690
- legal_relation
   - handoff 기대값: 18,461
   - import JSONL: 18,461
   - unique _point_id: 18,461
   - Qdrant count: 18,461
   - OpenSearch count: 18,461

## Related Issue
close #138 
