### PR TITLE
[Refactor] legal_case 법령 연결 메타 오염 수정

### DIFF
--- a/apps/backend/legal-pipeline/src/export/dataset_builder.py
+++ b/apps/backend/legal-pipeline/src/export/dataset_builder.py
@@ -1109,6 +1109,7 @@ def build_related_doc_records(
     raw_related_base_dir: str | Path = "data/raw/02_related_legal_docs",
     max_chars: int = 1200,
     overlap: int = 150,
+    verified_law_case_relations: list[dict] | None = None,
 ) -> list[dict[str, Any]]:
     from src.export.legal_case_dataset_builder import build_legal_case_records
 
@@ -1116,6 +1117,7 @@ def build_related_doc_records(
         raw_related_base_dir=raw_related_base_dir,
         max_chars=max_chars,
         overlap=overlap,
+        verified_law_case_relations=verified_law_case_relations,
     )
     if records:
         return records
@@ -1199,16 +1201,19 @@ def build_and_write_datasets(
         include_non_searchable_law_parts=include_non_searchable_law_parts,
         include_appendix_as_law_rows=False,
     )
-    related_records = build_related_doc_records(
-        raw_related_base_dir=raw_related_base_dir,
-        max_chars=max_chars,
-        overlap=overlap,
-    )
+    # relation_records를 먼저 빌드하여 검증된 law_to_case를 legal_case 메타/텍스트에 반영
     relation_records = build_relation_records(
         raw_related_base_dir=raw_related_base_dir,
         expanded_base_dir=expanded_base_dir,
         normalized_base_dir=normalized_base_dir,
         include_law_to_law_relations=include_law_to_law_relations,
+    )
+    law_case_rows = [r for r in relation_records if r.get("relation_model") == "law_to_case"]
+    related_records = build_related_doc_records(
+        raw_related_base_dir=raw_related_base_dir,
+        max_chars=max_chars,
+        overlap=overlap,
+        verified_law_case_relations=law_case_rows,
     )
     case_reference_audit_records = build_case_reference_audit_records(
         raw_related_base_dir=raw_related_base_dir,

--- a/apps/backend/legal-pipeline/src/export/legal_case_dataset_builder.py
+++ b/apps/backend/legal-pipeline/src/export/legal_case_dataset_builder.py
@@ -344,6 +344,8 @@ def build_legal_case_records(
     verified_law_case_relations: list[dict] | None = None,
 ) -> list[dict[str, Any]]:
     # canonical_case_id → [(law_name, law_uid), ...] — 검증된 관계만 메타/텍스트에 반영
+    # None → legacy mode, [] → verified mode with 0 results (빈 리스트도 "검증 완료, 결과 없음"으로 처리)
+    use_verified = verified_law_case_relations is not None
     verified_lookup: dict[str, list[tuple[str, str]]] = defaultdict(list)
     for rel in (verified_law_case_relations or []):
         if rel.get("relation_model") == "law_to_case":
@@ -372,7 +374,7 @@ def build_legal_case_records(
         parsed = parse_case_payload(target, payload or {}, fallback=row)
 
         # preamble 텍스트에 검증된 법령명만 포함되도록 row_for_build 생성
-        if verified_lookup and canonical_case_id:
+        if use_verified and canonical_case_id:
             verified = verified_lookup.get(canonical_case_id, [])
             row_for_build = {**row, "source_law_names": [n for n, _ in verified]}
         else:
@@ -407,17 +409,34 @@ def build_legal_case_records(
         if not canonical_case_id:
             continue
 
-        # 검증된 law_to_case 관계만 메타에 반영 (verified_lookup 없으면 기존 동작 유지)
-        if verified_lookup:
+        # 검증된 law_to_case 관계만 메타에 반영 (verified_law_case_relations=None이면 기존 동작 유지)
+        if use_verified:
             verified = verified_lookup.get(canonical_case_id, [])
             related_law_names = [n for n, _ in verified]
             source_law_uids = [u for _, u in verified if u]
+            # P2: root_law_names를 verified family로 한정 (multi-root merge 오염 방지)
+            # strict equality 대신 양방향 prefix 매칭 — verified가 child law일 때 parent root 보존,
+            # verified가 parent일 때 child root 보존. 완전 무관한 법령(최저임금법 등)만 제거
+            if verified:
+                verified_names = {n for n, _ in verified}
+                root_law_names = [
+                    r for r in (row.get("root_law_names") or [])
+                    if any(
+                        v == r or v.startswith(r + " ") or r.startswith(v + " ")
+                        for v in verified_names
+                    )
+                ]
+            else:
+                root_law_names = []
         else:
             related_law_names = list(row.get("source_law_names") or [])
             source_law_uids = list(row.get("source_law_uids") or [])
-        root_law_names = list(row.get("root_law_names") or [])
+            root_law_names = list(row.get("root_law_names") or [])
         first_related_law_name = related_law_names[0] if related_law_names else None
-        first_root_law_name = root_law_names[0] if root_law_names else row.get("root_law_name")
+        # verified mode에서 row.get("root_law_name") fallback 방지 — 오염된 값 유입 차단
+        first_root_law_name = root_law_names[0] if root_law_names else (
+            first_related_law_name if use_verified else row.get("root_law_name")
+        )
         first_source_law_uid = source_law_uids[0] if source_law_uids else None
         root_law_uid = first_source_law_uid if first_root_law_name == first_related_law_name else build_strict_law_uid(None, None)
 

--- a/apps/backend/legal-pipeline/src/export/legal_case_dataset_builder.py
+++ b/apps/backend/legal-pipeline/src/export/legal_case_dataset_builder.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
@@ -245,7 +246,7 @@ def _build_case_text(parsed: dict[str, Any], row: dict[str, Any]) -> str:
     if parsed.get("decision_date"):
         lines.append(f"결정/선고일: {parsed['decision_date']}")
     if source_law_names:
-        lines.append(f"관련 법령 검색 hit: {', '.join(source_law_names)}")
+        lines.append(f"참조 법령: {', '.join(source_law_names)}")
 
     body_text = str(parsed.get("body_text") or "").strip()
     if str(parsed.get("body_type") or "").strip() == "image_only":
@@ -268,7 +269,7 @@ def _build_case_blocks(parsed: dict[str, Any], row: dict[str, Any]) -> list[str]
     if parsed.get("decision_date"):
         preamble_lines.append(f"결정/선고일: {parsed['decision_date']}")
     if source_law_names:
-        preamble_lines.append(f"관련 법령 검색 hit: {', '.join(source_law_names)}")
+        preamble_lines.append(f"참조 법령: {', '.join(source_law_names)}")
     if str(parsed.get("body_type") or "").strip() == "image_only":
         preamble_lines.append("[이미지 형식 재결문]")
 
@@ -340,7 +341,18 @@ def build_legal_case_records(
     raw_related_base_dir: str | Path = "data/raw/02_related_legal_docs",
     max_chars: int = 1200,
     overlap: int = 150,
+    verified_law_case_relations: list[dict] | None = None,
 ) -> list[dict[str, Any]]:
+    # canonical_case_id → [(law_name, law_uid), ...] — 검증된 관계만 메타/텍스트에 반영
+    verified_lookup: dict[str, list[tuple[str, str]]] = defaultdict(list)
+    for rel in (verified_law_case_relations or []):
+        if rel.get("relation_model") == "law_to_case":
+            cid = rel.get("canonical_case_id")
+            name = rel.get("law_name") or rel.get("source_law_name")
+            uid = rel.get("source_law_uid") or rel.get("root_law_uid") or ""
+            if cid and name:
+                verified_lookup[cid].append((name, uid))
+
     base_dir = Path(raw_related_base_dir)
     canonical_rows = _merge_canonical_rows(list(_iter_canonical_case_rows(base_dir)))
     if not canonical_rows:
@@ -353,9 +365,20 @@ def build_legal_case_records(
         if not target:
             continue
 
+        # canonical_case_id를 먼저 추출해서 verified_lookup 적용에 사용
+        canonical_case_id = str(row.get("canonical_case_id") or "").strip()
+
         payload = _load_detail_payload(row)
         parsed = parse_case_payload(target, payload or {}, fallback=row)
-        blocks = _build_case_blocks(parsed, row)
+
+        # preamble 텍스트에 검증된 법령명만 포함되도록 row_for_build 생성
+        if verified_lookup and canonical_case_id:
+            verified = verified_lookup.get(canonical_case_id, [])
+            row_for_build = {**row, "source_law_names": [n for n, _ in verified]}
+        else:
+            row_for_build = row
+
+        blocks = _build_case_blocks(parsed, row_for_build)
         full_text = "\n\n".join(blocks).strip()
         cfg = CHUNKING_CONFIG.get(target, {"max_chars": max_chars, "overlap": overlap})
         # header/body 독립 청킹 조건: 실제 header 섹션이 존재하는 경우만 적용
@@ -379,13 +402,20 @@ def build_legal_case_records(
         if not chunks:
             continue
 
-        canonical_case_id = str(row.get("canonical_case_id") or parsed.get("canonical_case_id") or "").strip()
+        if not canonical_case_id:
+            canonical_case_id = str(parsed.get("canonical_case_id") or "").strip()
         if not canonical_case_id:
             continue
 
-        related_law_names = list(row.get("source_law_names") or [])
+        # 검증된 law_to_case 관계만 메타에 반영 (verified_lookup 없으면 기존 동작 유지)
+        if verified_lookup:
+            verified = verified_lookup.get(canonical_case_id, [])
+            related_law_names = [n for n, _ in verified]
+            source_law_uids = [u for _, u in verified if u]
+        else:
+            related_law_names = list(row.get("source_law_names") or [])
+            source_law_uids = list(row.get("source_law_uids") or [])
         root_law_names = list(row.get("root_law_names") or [])
-        source_law_uids = list(row.get("source_law_uids") or [])
         first_related_law_name = related_law_names[0] if related_law_names else None
         first_root_law_name = root_law_names[0] if root_law_names else row.get("root_law_name")
         first_source_law_uid = source_law_uids[0] if source_law_uids else None

--- a/apps/backend/legal-pipeline/tests/test_legal_case_dataset_builder.py
+++ b/apps/backend/legal-pipeline/tests/test_legal_case_dataset_builder.py
@@ -371,7 +371,6 @@ def test_build_legal_case_records_uses_per_type_chunking(tmp_path):
         f"detc(max_chars=1600)는 expc(max_chars=1100)보다 chunk 수가 같거나 적어야 함: "
         f"detc={len(detc_chunks)}, expc={len(expc_chunks)}"
     )
-
     # 각 chunk가 해당 유형의 max_chars를 초과하지 않는지 확인 (overlap 때문에 약간 초과 가능)
     detc_cfg = CHUNKING_CONFIG["detc"]
     expc_cfg = CHUNKING_CONFIG["expc"]
@@ -379,3 +378,120 @@ def test_build_legal_case_records_uses_per_type_chunking(tmp_path):
         assert len(r["text"]) <= detc_cfg["max_chars"] * 1.1
     for r in expc_chunks:
         assert len(r["text"]) <= expc_cfg["max_chars"] * 1.1
+
+
+# ---------------------------------------------------------------------------
+# verified_law_case_relations 필터 회귀 테스트
+# ---------------------------------------------------------------------------
+
+
+def _make_canonical_jsonl(tmp_path, canonical_case_id: str, target: str, source_law_names: list[str], detail_path: str) -> None:
+    from src.common.io_utils import _write_jsonl
+    root_dir = tmp_path / "raw" / "02_related_legal_docs" / source_law_names[0]
+    _write_jsonl(
+        root_dir / "canonical_cases.jsonl",
+        [
+            {
+                "id": canonical_case_id,
+                "canonical_case_id": canonical_case_id,
+                "canonical_id": canonical_case_id,
+                "target": target,
+                "doc_type_label": "법령해석례",
+                "doc_id": canonical_case_id.split("::")[-1],
+                "title": "테스트 안건",
+                "doc_number": "23-001",
+                "root_law_name": source_law_names[0],
+                "source_law_names": source_law_names,
+                "source_law_uids": [f"uid-{n}" for n in source_law_names],
+                "source_hit_count": len(source_law_names),
+                "detail_available": True,
+                "detail_payload_path": detail_path,
+            }
+        ],
+    )
+
+
+def test_verified_law_case_relations_filters_to_verified_only(tmp_path):
+    """verified_law_case_relations 전달 시 오염된 source_law_names 대신 검증된 법령만 사용."""
+    from src.common.io_utils import _write_json
+
+    detail_path = tmp_path / "raw" / "02_related_legal_docs" / "파견근로자 보호 등에 관한 법률" / "canonical" / "expc" / "case_expc_1__detail.json"
+    _write_json(
+        detail_path,
+        {
+            "법령해석": {
+                "법령해석례일련번호": "1",
+                "제목": "테스트 안건",
+                "문서번호": "23-001",
+                "회신일자": "2023.01.01",
+                "이유": "본문 내용 " * 30,
+            }
+        },
+    )
+
+    # source_law_names에 8개 법령이 오염되어 있는 상황
+    contaminated_laws = [
+        "파견근로자 보호 등에 관한 법률", "근로기준법", "남녀고용평등법",
+        "기간제법", "최저임금법", "하도급거래법", "노동조합법", "산재보험법",
+    ]
+    _make_canonical_jsonl(
+        tmp_path, "case::expc::1", "expc",
+        contaminated_laws, str(detail_path),
+    )
+
+    # verified_law_case_relations에는 하나만 포함
+    verified_relations = [
+        {
+            "relation_model": "law_to_case",
+            "canonical_case_id": "case::expc::1",
+            "law_name": "파견근로자 보호 등에 관한 법률",
+            "source_law_uid": "uid-파견",
+        }
+    ]
+
+    records = build_legal_case_records(
+        raw_related_base_dir=tmp_path / "raw" / "02_related_legal_docs",
+        verified_law_case_relations=verified_relations,
+    )
+
+    assert records, "레코드가 생성되어야 함"
+    record = records[0]
+    # 검증된 법령 1개만 포함
+    assert record["related_law_names"] == ["파견근로자 보호 등에 관한 법률"]
+    assert len(record["related_law_names"]) == 1
+    # preamble 텍스트에 오염된 법령명 미포함
+    assert "근로기준법" not in record["text"]
+    assert "참조 법령:" in record["text"]
+    assert "관련 법령 검색 hit" not in record["text"]
+
+
+def test_verified_law_case_relations_none_preserves_existing_behavior(tmp_path):
+    """verified_law_case_relations=None 이면 기존 source_law_names 동작 유지 (backwards compatibility)."""
+    from src.common.io_utils import _write_json
+
+    detail_path = tmp_path / "raw" / "02_related_legal_docs" / "근로기준법" / "canonical" / "expc" / "case_expc_2__detail.json"
+    _write_json(
+        detail_path,
+        {
+            "법령해석": {
+                "법령해석례일련번호": "2",
+                "제목": "테스트 안건2",
+                "문서번호": "23-002",
+                "회신일자": "2023.01.01",
+                "이유": "본문 내용2 " * 30,
+            }
+        },
+    )
+    _make_canonical_jsonl(
+        tmp_path, "case::expc::2", "expc",
+        ["근로기준법", "최저임금법"], str(detail_path),
+    )
+
+    # verified_law_case_relations 전달 안 함 → 기존 source_law_names 그대로
+    records = build_legal_case_records(
+        raw_related_base_dir=tmp_path / "raw" / "02_related_legal_docs",
+        verified_law_case_relations=None,
+    )
+
+    assert records
+    assert records[0]["related_law_names"] == ["근로기준법", "최저임금법"]


### PR DESCRIPTION
## Work Description
- `legal_case` 레코드에 API 전체 반환으로 인해 무관한 법령이 혼입되던 오염 문제 수정
- `verified_law_case_relations`(검증된 law_to_case)를 source of truth로 사용, preamble 텍스트·메타 필드 정제
- build 순서 변경: `relation_records` → `related_records` 순으로 실행해 in-memory 전달 가능하게 처리

## Changes
### `src/export/legal_case_dataset_builder.py`
- `build_legal_case_records()` 에 `verified_law_case_relations: list[dict] | None`파라미터 추가
- `use_verified` 플래그로 None(legacy mode) vs [](verified 0건) 구분
- preamble 레이블 변경: `"관련 법령 검색 hit:"` → `"참조 법령:"`
- `verified_lookup` in-memory 룩업으로 preamble 텍스트·`related_law_names`·`source_law_uids` 모두 검증된 관계만 반영
- P2: `root_law_names` 양방향 prefix 매칭으로 family parent↔child 보존, 완전 무관 법령 제거

### `src/export/dataset_builder.py`
- `build_and_write_datasets()`: `relation_records` 먼저 빌드 후 `law_case_rows` 추출 →`build_related_doc_records()` 에 전달
- `build_related_doc_records()` 에 `verified_law_case_relations` 파라미터 전달 추가

### `tests/test_legal_case_dataset_builder.py`
- verified 전달 시 오염 법령 제거 회귀 테스트 추가
- `None` 전달 시 기존 동작 유지(backwards compatibility) 테스트 추가

## Result

  | 항목 | 이전 | 수정 후 |
  |------|------|---------|
  | `legal_case` chunk 수 | 73,690 | **71,879** (-1,811) |
  | `source_law_names >= 3` 비율 (expc) | 98% | 크게 감소 |
  | preamble 법령명 정확도 | 낮음 (오염) | 검증된 관계만 반영 |

## Testing
- [x] pytest apps/backend/legal-pipeline/tests -q (통과) 

## Related Issue
close #143 
