### PR TITLE
[Refactor] apps/backend/law-updater  legal-pipeline과 동기화  

### DIFF
--- a/apps/backend/law-updater/src/export/dataset_builder.py
+++ b/apps/backend/law-updater/src/export/dataset_builder.py
@@ -1109,6 +1109,7 @@ def build_related_doc_records(
     raw_related_base_dir: str | Path = "data/raw/02_related_legal_docs",
     max_chars: int = 1200,
     overlap: int = 150,
+    verified_law_case_relations: list[dict] | None = None,
 ) -> list[dict[str, Any]]:
     from src.export.legal_case_dataset_builder import build_legal_case_records
 
@@ -1116,6 +1117,7 @@ def build_related_doc_records(
         raw_related_base_dir=raw_related_base_dir,
         max_chars=max_chars,
         overlap=overlap,
+        verified_law_case_relations=verified_law_case_relations,
     )
     if records:
         return records
@@ -1133,6 +1135,7 @@ def build_relation_records(
     expanded_base_dir: str | Path = "data/expanded/03_expanded_related_docs",
     normalized_base_dir: str | Path | None = None,
     include_law_to_law_relations: bool = True,
+    include_case_to_case_relations: bool = True,
 ) -> list[dict[str, Any]]:
     from src.export.legal_relation_builder import build_legal_relation_records
     from src.export.law_to_law_relation_builder import build_law_to_law_relation_records
@@ -1149,6 +1152,13 @@ def build_relation_records(
 
     if include_law_to_law_relations and normalized_base_dir is not None:
         records.extend(build_law_to_law_relation_records(normalized_base_dir=normalized_base_dir))
+
+    if include_case_to_case_relations:
+        from src.export.legal_case_relation_builder import build_case_to_case_relation_records
+        records.extend(build_case_to_case_relation_records(
+            raw_related_base_dir=raw_related_base_dir,
+            skip_source_targets={"decc"},
+        ))
 
     records.sort(key=lambda row: str(row.get("id") or ""))
     return records
@@ -1191,22 +1201,35 @@ def build_and_write_datasets(
         include_non_searchable_law_parts=include_non_searchable_law_parts,
         include_appendix_as_law_rows=False,
     )
-    related_records = build_related_doc_records(
-        raw_related_base_dir=raw_related_base_dir,
-        max_chars=max_chars,
-        overlap=overlap,
-    )
+    # relation_records를 먼저 빌드하여 검증된 law_to_case를 legal_case 메타/텍스트에 반영
     relation_records = build_relation_records(
         raw_related_base_dir=raw_related_base_dir,
         expanded_base_dir=expanded_base_dir,
         normalized_base_dir=normalized_base_dir,
         include_law_to_law_relations=include_law_to_law_relations,
     )
+    law_case_rows = [r for r in relation_records if r.get("relation_model") == "law_to_case"]
+    related_records = build_related_doc_records(
+        raw_related_base_dir=raw_related_base_dir,
+        max_chars=max_chars,
+        overlap=overlap,
+        verified_law_case_relations=law_case_rows,
+    )
     case_reference_audit_records = build_case_reference_audit_records(
         raw_related_base_dir=raw_related_base_dir,
     )
 
     appendix_manifest: dict[str, Any] | None = None
+    if normalized_appendix_base_dir is not None and write_legacy_appendix_datasets:
+        from src.export.appendix_dataset_builder import build_and_write_appendix_datasets
+
+        appendix_manifest = build_and_write_appendix_datasets(
+            normalized_appendix_base_dir=normalized_appendix_base_dir,
+            output_dir=output_dir,
+            max_chars=max_chars,
+            overlap=overlap,
+            normalized_appendix_asset_base_dir=normalized_appendix_asset_base_dir,
+        )
 
     article_appendix_manifest: dict[str, Any] | None = None
     if merge_appendices_into_law_article and normalized_appendix_base_dir is not None:
@@ -1250,9 +1273,16 @@ def build_and_write_datasets(
         ),
     }
 
+    case_to_case_count = sum(1 for r in relation_records if r.get("relation_model") == "case_to_case")
+    law_to_law_count = sum(1 for r in relation_records if r.get("relation_model") == "law_to_law")
+    law_to_case_count = sum(1 for r in relation_records if r.get("relation_model") == "law_to_case")
+
     manifest = {
         "legal_corpus_count": len(legal_corpus_records),
         "legal_relations_count": len(relation_records),
+        "law_to_case_count": law_to_case_count,
+        "law_to_law_count": law_to_law_count,
+        "case_to_case_count": case_to_case_count,
         "law_record_count": len(law_records),
         "related_doc_record_count": len(related_records),
         "case_reference_audit_manifest": case_reference_audit_manifest,

--- a/apps/backend/law-updater/src/export/legal_case_dataset_builder.py
+++ b/apps/backend/law-updater/src/export/legal_case_dataset_builder.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
@@ -9,6 +10,34 @@ from src.common.law_meta import build_law_uid, build_strict_law_uid
 from src.common.io_utils import _iter_jsonl, _read_json
 from src.parser.legal_case_parser import parse_case_payload
 
+
+CHUNKING_CONFIG: dict[str, dict[str, int]] = {
+    "prec": {"max_chars": 1400, "overlap": 180},
+    "detc": {"max_chars": 1600, "overlap": 200},
+    "expc": {"max_chars": 1100, "overlap": 120},
+    "decc": {"max_chars": 1400, "overlap": 180},
+}
+
+# header: 짧고 핵심적인 요약/참조 필드 → 첫 청크에 preamble과 함께 유지
+# body:   장문 본문 필드 → overlap 청킹 적용
+FIELD_GROUPS: dict[str, dict[str, list[str]]] = {
+    "prec": {
+        "header": ["판시사항", "판결요지", "참조조문", "참조판례"],
+        "body":   ["판례내용"],
+    },
+    "detc": {
+        "header": ["판시사항", "결정요지", "심판대상조문", "참조조문", "참조판례"],
+        "body":   ["전문"],
+    },
+    "expc": {
+        "header": ["질의요지", "회답"],
+        "body":   ["이유"],
+    },
+    "decc": {
+        "header": ["청구취지", "주문", "재결요지"],
+        "body":   ["이유"],
+    },
+}
 
 
 def _normalize_space(text: str) -> str:
@@ -67,6 +96,36 @@ def _chunk_text(text: str, max_chars: int = 1200, overlap: int = 150) -> list[st
         if end >= len(text):
             break
         start = max(0, end - overlap)
+
+    return chunks
+
+
+def _chunk_blocks(blocks: list[str], max_chars: int = 1200, overlap: int = 150) -> list[str]:
+    normalized_blocks = [_normalize_structure(block) for block in blocks if _normalize_structure(block)]
+    if not normalized_blocks:
+        return []
+
+    chunks: list[str] = []
+    current = ""
+
+    for block in normalized_blocks:
+        candidate = block if not current else f"{current}\n\n{block}"
+        if len(candidate) <= max_chars:
+            current = candidate
+            continue
+
+        if current:
+            chunks.append(current)
+            current = ""
+
+        if len(block) <= max_chars:
+            current = block
+            continue
+
+        chunks.extend(_chunk_text(block, max_chars=max_chars, overlap=overlap))
+
+    if current:
+        chunks.append(current)
 
     return chunks
 
@@ -187,13 +246,94 @@ def _build_case_text(parsed: dict[str, Any], row: dict[str, Any]) -> str:
     if parsed.get("decision_date"):
         lines.append(f"결정/선고일: {parsed['decision_date']}")
     if source_law_names:
-        lines.append(f"관련 법령 검색 hit: {', '.join(source_law_names)}")
+        lines.append(f"참조 법령: {', '.join(source_law_names)}")
 
     body_text = str(parsed.get("body_text") or "").strip()
+    if str(parsed.get("body_type") or "").strip() == "image_only":
+        lines.append("[이미지 형식 재결문]")
     if body_text:
         lines.append(body_text)
 
     return "\n".join(line for line in lines if line).strip()
+
+
+def _build_case_blocks(parsed: dict[str, Any], row: dict[str, Any]) -> list[str]:
+    target = str(parsed.get("target") or row.get("target") or "").strip()
+    source_law_names = row.get("source_law_names") or []
+    preamble_lines = [f"문서 유형: {DOC_TYPE_LABELS.get(target, target)}"]
+
+    if parsed.get("title"):
+        preamble_lines.append(f"문서 제목: {parsed['title']}")
+    if parsed.get("doc_number"):
+        preamble_lines.append(f"문서 번호: {parsed['doc_number']}")
+    if parsed.get("decision_date"):
+        preamble_lines.append(f"결정/선고일: {parsed['decision_date']}")
+    if source_law_names:
+        preamble_lines.append(f"참조 법령: {', '.join(source_law_names)}")
+    if str(parsed.get("body_type") or "").strip() == "image_only":
+        preamble_lines.append("[이미지 형식 재결문]")
+
+    preamble = "\n".join(line for line in preamble_lines if line).strip()
+
+    body_sections = parsed.get("body_sections") or []
+    if not (isinstance(body_sections, list) and body_sections):
+        full_text = _build_case_text(parsed, row)
+        return [full_text] if full_text else []
+
+    field_group = FIELD_GROUPS.get(target)
+    if not field_group:
+        # 알 수 없는 target: 기존 방식 (preamble + 개별 섹션 블록)
+        blocks = [preamble] if preamble else []
+        for section in body_sections:
+            if not isinstance(section, dict):
+                continue
+            label = str(section.get("label") or "").strip()
+            text = _normalize_structure(str(section.get("text") or ""))
+            if text:
+                blocks.append(f"{label}\n{text}" if label else text)
+        return [block for block in blocks if block]
+
+    header_labels = set(field_group["header"])
+    body_labels = set(field_group["body"])
+
+    # preamble을 header_parts의 첫 요소로 포함하여 첫 청크에 보장
+    header_parts: list[str] = [preamble] if preamble else []
+    body_blocks: list[str] = []
+    extra_blocks: list[str] = []
+
+    for section in body_sections:
+        if not isinstance(section, dict):
+            continue
+        label = str(section.get("label") or "").strip()
+        text = _normalize_structure(str(section.get("text") or ""))
+        if not text:
+            continue
+        formatted = f"{label}\n{text}" if label else text
+        if label in header_labels:
+            header_parts.append(formatted)
+        elif label in body_labels:
+            body_blocks.append(formatted)
+        else:
+            extra_blocks.append(formatted)
+
+    # header 실질 내용 유무 판단 (preamble만 있으면 "없음"으로 간주)
+    has_real_header = len(header_parts) > (1 if preamble else 0)
+
+    if has_real_header:
+        # 정상: preamble + header sections → 첫 블록 (기존 동작 유지)
+        first_block = "\n\n".join(header_parts)
+        blocks = [first_block] + extra_blocks + body_blocks
+    else:
+        # header 없음: preamble 단독 짧은 첫 청크 방지
+        # preamble을 첫 content 블록(extra → body 순서) 앞에 합침
+        all_content = extra_blocks + body_blocks
+        if all_content and preamble:
+            all_content[0] = f"{preamble}\n\n{all_content[0]}"
+        elif preamble:
+            all_content = [preamble]
+        blocks = all_content
+
+    return [block for block in blocks if block]
 
 
 
@@ -201,7 +341,20 @@ def build_legal_case_records(
     raw_related_base_dir: str | Path = "data/raw/02_related_legal_docs",
     max_chars: int = 1200,
     overlap: int = 150,
+    verified_law_case_relations: list[dict] | None = None,
 ) -> list[dict[str, Any]]:
+    # canonical_case_id → [(law_name, law_uid), ...] — 검증된 관계만 메타/텍스트에 반영
+    # None → legacy mode, [] → verified mode with 0 results (빈 리스트도 "검증 완료, 결과 없음"으로 처리)
+    use_verified = verified_law_case_relations is not None
+    verified_lookup: dict[str, list[tuple[str, str]]] = defaultdict(list)
+    for rel in (verified_law_case_relations or []):
+        if rel.get("relation_model") == "law_to_case":
+            cid = rel.get("canonical_case_id")
+            name = rel.get("law_name") or rel.get("source_law_name")
+            uid = rel.get("source_law_uid") or rel.get("root_law_uid") or ""
+            if cid and name:
+                verified_lookup[cid].append((name, uid))
+
     base_dir = Path(raw_related_base_dir)
     canonical_rows = _merge_canonical_rows(list(_iter_canonical_case_rows(base_dir)))
     if not canonical_rows:
@@ -214,24 +367,76 @@ def build_legal_case_records(
         if not target:
             continue
 
+        # canonical_case_id를 먼저 추출해서 verified_lookup 적용에 사용
+        canonical_case_id = str(row.get("canonical_case_id") or "").strip()
+
         payload = _load_detail_payload(row)
         parsed = parse_case_payload(target, payload or {}, fallback=row)
-        full_text = _build_case_text(parsed, row)
-        chunks = _chunk_text(full_text, max_chars=max_chars, overlap=overlap)
+
+        # preamble 텍스트에 검증된 법령명만 포함되도록 row_for_build 생성
+        if use_verified and canonical_case_id:
+            verified = verified_lookup.get(canonical_case_id, [])
+            row_for_build = {**row, "source_law_names": [n for n, _ in verified]}
+        else:
+            row_for_build = row
+
+        blocks = _build_case_blocks(parsed, row_for_build)
+        full_text = "\n\n".join(blocks).strip()
+        cfg = CHUNKING_CONFIG.get(target, {"max_chars": max_chars, "overlap": overlap})
+        # header/body 독립 청킹 조건: 실제 header 섹션이 존재하는 경우만 적용
+        # len(blocks) > 1 만으로는 부족 — header 없는 다중 블록을 잘못 처리할 수 있음
+        field_group = FIELD_GROUPS.get(target)
+        has_real_header = field_group is not None and any(
+            str(s.get("label") or "").strip() in field_group["header"]
+            for s in (parsed.get("body_sections") or [])
+            if isinstance(s, dict) and str(s.get("text") or "").strip()
+        )
+        if has_real_header and len(blocks) > 1:
+            # 첫 블록(preamble+header)과 본문 블록을 독립 청킹하여 합산 방지
+            # 첫 블록 초과 시 overlap=0으로 분할 (헤더 중복 방지)
+            first_chunks = _chunk_blocks(blocks[:1], max_chars=cfg["max_chars"], overlap=0)
+            body_chunks = _chunk_blocks(blocks[1:], max_chars=cfg["max_chars"], overlap=cfg["overlap"])
+            chunks = first_chunks + body_chunks
+        else:
+            chunks = _chunk_blocks(blocks, max_chars=cfg["max_chars"], overlap=cfg["overlap"])
         if not chunks and full_text:
             chunks = [full_text]
         if not chunks:
             continue
 
-        canonical_case_id = str(row.get("canonical_case_id") or parsed.get("canonical_case_id") or "").strip()
+        if not canonical_case_id:
+            canonical_case_id = str(parsed.get("canonical_case_id") or "").strip()
         if not canonical_case_id:
             continue
 
-        related_law_names = list(row.get("source_law_names") or [])
-        root_law_names = list(row.get("root_law_names") or [])
-        source_law_uids = list(row.get("source_law_uids") or [])
+        # 검증된 law_to_case 관계만 메타에 반영 (verified_law_case_relations=None이면 기존 동작 유지)
+        if use_verified:
+            verified = verified_lookup.get(canonical_case_id, [])
+            related_law_names = [n for n, _ in verified]
+            source_law_uids = [u for _, u in verified if u]
+            # P2: root_law_names를 verified family로 한정 (multi-root merge 오염 방지)
+            # strict equality 대신 양방향 prefix 매칭 — verified가 child law일 때 parent root 보존,
+            # verified가 parent일 때 child root 보존. 완전 무관한 법령(최저임금법 등)만 제거
+            if verified:
+                verified_names = {n for n, _ in verified}
+                root_law_names = [
+                    r for r in (row.get("root_law_names") or [])
+                    if any(
+                        v == r or v.startswith(r + " ") or r.startswith(v + " ")
+                        for v in verified_names
+                    )
+                ]
+            else:
+                root_law_names = []
+        else:
+            related_law_names = list(row.get("source_law_names") or [])
+            source_law_uids = list(row.get("source_law_uids") or [])
+            root_law_names = list(row.get("root_law_names") or [])
         first_related_law_name = related_law_names[0] if related_law_names else None
-        first_root_law_name = root_law_names[0] if root_law_names else row.get("root_law_name")
+        # verified mode에서 row.get("root_law_name") fallback 방지 — 오염된 값 유입 차단
+        first_root_law_name = root_law_names[0] if root_law_names else (
+            first_related_law_name if use_verified else row.get("root_law_name")
+        )
         first_source_law_uid = source_law_uids[0] if source_law_uids else None
         root_law_uid = first_source_law_uid if first_root_law_name == first_related_law_name else build_strict_law_uid(None, None)
 

--- a/apps/backend/law-updater/src/export/legal_case_relation_builder.py
+++ b/apps/backend/law-updater/src/export/legal_case_relation_builder.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
+from src.common.io_utils import _safe_filename
 from src.export.legal_case_dataset_builder import (
     _iter_canonical_case_rows,
     _load_detail_payload,
@@ -50,6 +51,47 @@ def _build_doc_number_index(canonical_rows: list[dict[str, Any]]) -> dict[str, l
     return index
 
 
+def _merge_referenced_case_numbers(
+    parsed: dict[str, Any],
+    body_text: str,
+    source_doc_number: Any,
+) -> list[dict[str, Any]]:
+    merged: dict[str, dict[str, Any]] = {}
+
+    for item in parsed.get("structured_case_refs") or []:
+        if not isinstance(item, dict):
+            continue
+        case_number = str(item.get("case_number") or "").strip()
+        normalized = _normalize_case_number(case_number)
+        if not normalized:
+            continue
+        entry = merged.setdefault(
+            normalized,
+            {
+                "case_number": case_number,
+                "reference_sources": [],
+            },
+        )
+        if "structured_field" not in entry["reference_sources"]:
+            entry["reference_sources"].append("structured_field")
+
+    for case_number in extract_case_number_refs(body_text, exclude_numbers=[source_doc_number]):
+        normalized = _normalize_case_number(case_number)
+        if not normalized:
+            continue
+        entry = merged.setdefault(
+            normalized,
+            {
+                "case_number": case_number,
+                "reference_sources": [],
+            },
+        )
+        if "body_regex" not in entry["reference_sources"]:
+            entry["reference_sources"].append("body_regex")
+
+    return [merged[key] for key in sorted(merged)]
+
+
 def _iter_case_reference_candidates(
     raw_related_base_dir: str | Path,
 ) -> tuple[list[dict[str, Any]], dict[str, list[dict[str, Any]]], list[dict[str, Any]]]:
@@ -57,12 +99,46 @@ def _iter_case_reference_candidates(
     return canonical_rows, _build_doc_number_index(canonical_rows), canonical_rows
 
 
+def _load_expc_related_prec_ids(row: dict[str, Any], base_dir: Path) -> list[str]:
+    """expc HTML 수집 결과(sidecar JSON)에서 관련 prec ID를 로드한다."""
+    canonical_case_id = str(
+        row.get("canonical_case_id") or row.get("canonical_id") or row.get("id") or ""
+    ).strip()
+    if not canonical_case_id:
+        return []
+    root_dir = _safe_filename(str(row.get("root_law_name") or ""))
+    safe_id = canonical_case_id.replace("::", "__").replace("/", "_")
+    sidecar = base_dir / root_dir / "canonical" / "expc" / f"{safe_id}__related_prec_ids.json"
+    if not sidecar.exists():
+        return []
+    try:
+        import json
+        data = json.loads(sidecar.read_text(encoding="utf-8"))
+        return list(data.get("related_prec_ids") or [])
+    except Exception:
+        return []
+
+
 def build_case_to_case_relation_records(
     raw_related_base_dir: str | Path = "data/raw/02_related_legal_docs",
+    skip_source_targets: set[str] | None = None,
+    use_body_regex_fallback: bool = False,
 ) -> list[dict[str, Any]]:
+    from src.parser.legal_case_parser import classify_case_type_from_number
+
+    skip_targets = skip_source_targets or set()
+    base_dir = Path(raw_related_base_dir)
     canonical_rows, doc_number_index, _ = _iter_case_reference_candidates(raw_related_base_dir)
     if not canonical_rows:
         return []
+
+    # doc_id → canonical row 인덱스 (expc HTML prec_id 해결용)
+    doc_id_index: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for cr in canonical_rows:
+        did = str(cr.get("doc_id") or "").strip()
+        if did:
+            doc_id_index[did].append(cr)
+
     records_by_id: dict[str, dict[str, Any]] = {}
 
     for row in canonical_rows:
@@ -73,24 +149,87 @@ def build_case_to_case_relation_records(
             continue
 
         source_target = str(row.get("target") or "").strip()
-        if not source_target:
+        if not source_target or source_target in skip_targets:
             continue
 
+        # expc: HTML sidecar 기반 관계 추출
+        if source_target == "expc":
+            prec_ids = _load_expc_related_prec_ids(row, base_dir)
+            for prec_id in prec_ids:
+                candidates = [
+                    c for c in doc_id_index.get(prec_id, [])
+                    if str(c.get("target") or "").strip() in ("prec",)
+                    and str(c.get("canonical_case_id") or c.get("canonical_id") or c.get("id") or "").strip()
+                    != source_canonical_case_id
+                ]
+                if len(candidates) != 1:
+                    continue
+                target_row = candidates[0]
+                target_cid = str(
+                    target_row.get("canonical_case_id") or target_row.get("canonical_id") or target_row.get("id") or ""
+                ).strip()
+                if not target_cid:
+                    continue
+                relation_id = f"case_relation::{source_canonical_case_id}::{target_cid}"
+                if relation_id in records_by_id:
+                    continue
+                record = {
+                    "id": relation_id,
+                    "canonical_id": source_canonical_case_id,
+                    "canonical_case_id": source_canonical_case_id,
+                    "source_canonical_case_id": source_canonical_case_id,
+                    "target_canonical_case_id": target_cid,
+                    "doc_type": "relation",
+                    "doc_type_label": "법령해석례",
+                    "source_group": "04_case_to_case_relations",
+                    "relation_model": "case_to_case",
+                    "relation_type": "cited_prec_html",
+                    "relation_types": ["cited_prec_html"],
+                    "relation_confidence": 0.92,
+                    "resolution_status": "resolved",
+                    "source_case_type": "expc",
+                    "target_case_type": "prec",
+                    "relation_subtype": "expc_to_prec",
+                    "target": source_target,
+                    "source_target": source_target,
+                    "target_target": target_row.get("target"),
+                    "title": row.get("title"),
+                    "doc_id": row.get("doc_id"),
+                    "doc_number": row.get("doc_number"),
+                    "target_title": target_row.get("title"),
+                    "target_doc_id": target_row.get("doc_id"),
+                    "target_doc_number": target_row.get("doc_number"),
+                    "target_doc_type_label": target_row.get("doc_type_label"),
+                    "referenced_case_number": target_row.get("doc_number"),
+                    "reference_sources": ["html_scraping"],
+                    "root_law_name": row.get("root_law_name"),
+                    "root_law_names": row.get("root_law_names") or [],
+                    "related_law_names": row.get("source_law_names") or [],
+                    "source_law_name": (row.get("source_law_names") or [None])[0],
+                    "source_law_names": row.get("source_law_names") or [],
+                    "source_hit_count": row.get("source_hit_count"),
+                    "source_file_path": row.get("detail_payload_path") or row.get("_canonical_index_path"),
+                    "evidence_preview": "",
+                }
+                record["embedding_text"] = _build_case_to_case_text(record)
+                record["text"] = record["embedding_text"]
+                records_by_id[relation_id] = record
+            continue
+
+        # prec/detc: structured field 기반 관계 추출
         payload = _load_detail_payload(row)
         parsed = parse_case_payload(source_target, payload or {}, fallback=row)
         source_doc_number = parsed.get("doc_number") or row.get("doc_number")
         body_text = str(parsed.get("body_text") or "").strip()
-        if not body_text:
-            continue
 
-        referenced_case_numbers = extract_case_number_refs(
-            body_text,
-            exclude_numbers=[source_doc_number],
+        referenced_case_rows = _merge_referenced_case_numbers(
+            parsed, body_text if use_body_regex_fallback else "", source_doc_number
         )
-        if not referenced_case_numbers:
+        if not referenced_case_rows:
             continue
 
-        for referenced_case_number in referenced_case_numbers:
+        for ref_row in referenced_case_rows:
+            referenced_case_number = str(ref_row.get("case_number") or "").strip()
             normalized_ref = _normalize_case_number(referenced_case_number)
             if not normalized_ref:
                 continue
@@ -111,9 +250,15 @@ def build_case_to_case_relation_records(
             if not target_canonical_case_id:
                 continue
 
+            target_case_type = str(target_row.get("target") or "").strip()
+            if not target_case_type:
+                target_case_type = classify_case_type_from_number(referenced_case_number) or ""
+
             relation_id = f"case_relation::{source_canonical_case_id}::{target_canonical_case_id}"
             if relation_id in records_by_id:
                 continue
+
+            relation_subtype = f"{source_target}_to_{target_case_type}" if target_case_type else None
 
             record = {
                 "id": relation_id,
@@ -129,6 +274,9 @@ def build_case_to_case_relation_records(
                 "relation_types": ["cited_case"],
                 "relation_confidence": 0.95,
                 "resolution_status": "resolved",
+                "source_case_type": source_target,
+                "target_case_type": target_case_type,
+                "relation_subtype": relation_subtype,
                 "target": source_target,
                 "source_target": source_target,
                 "target_target": target_row.get("target"),
@@ -143,6 +291,7 @@ def build_case_to_case_relation_records(
                 "target_doc_number": target_row.get("doc_number"),
                 "target_doc_type_label": target_row.get("doc_type_label"),
                 "referenced_case_number": referenced_case_number,
+                "reference_sources": list(ref_row.get("reference_sources") or []),
                 "root_law_name": row.get("root_law_name"),
                 "root_law_names": row.get("root_law_names") or [],
                 "related_law_names": row.get("source_law_names") or [],
@@ -186,14 +335,10 @@ def build_case_reference_audit_records(
         parsed = parse_case_payload(source_target, payload or {}, fallback=row)
         source_doc_number = parsed.get("doc_number") or row.get("doc_number")
         body_text = str(parsed.get("body_text") or "").strip()
-        if not body_text:
-            continue
 
-        referenced_case_numbers = extract_case_number_refs(
-            body_text,
-            exclude_numbers=[source_doc_number],
-        )
-        for referenced_case_number in referenced_case_numbers:
+        referenced_case_rows = _merge_referenced_case_numbers(parsed, body_text, source_doc_number)
+        for ref_row in referenced_case_rows:
+            referenced_case_number = str(ref_row.get("case_number") or "").strip()
             normalized_ref = _normalize_case_number(referenced_case_number)
             if not normalized_ref:
                 continue
@@ -231,6 +376,7 @@ def build_case_reference_audit_records(
                     "source_title": parsed.get("title"),
                     "source_doc_number": source_doc_number,
                     "referenced_case_number": referenced_case_number,
+                    "reference_sources": list(ref_row.get("reference_sources") or []),
                     "normalized_referenced_case_number": normalized_ref,
                     "resolution_status": resolution_status,
                     "candidate_count": len(candidate_rows),

--- a/apps/backend/law-updater/src/export/legal_relation_builder.py
+++ b/apps/backend/law-updater/src/export/legal_relation_builder.py
@@ -496,7 +496,8 @@ def _dedup_family_search_hits(rows: list[dict[str, Any]]) -> list[dict[str, Any]
             continue
         case_id = str(row.get("canonical_case_id") or row.get("canonical_id") or "").strip()
         root_uid = str(row.get("root_law_uid") or "").strip()
-        key = (case_id, root_uid)
+        root_law_name = str(row.get("root_law_name") or "").strip()
+        key = (case_id, root_uid if root_uid else root_law_name)
         search_hit_only.setdefault(key, []).append(row)
 
     for group_rows in search_hit_only.values():

--- a/apps/backend/law-updater/src/export/legal_relation_builder.py
+++ b/apps/backend/law-updater/src/export/legal_relation_builder.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import logging
 from collections import defaultdict
 from pathlib import Path
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 from src.common.io_utils import _iter_jsonl, _read_json, _write_jsonl
 from src.common.law_meta import build_law_uid
@@ -146,12 +149,70 @@ def _confidence(
     article_refs: list[dict[str, str]],
     matched_law_names: list[str],
     law_name: str,
+    has_structured_article_ref: bool = False,
 ) -> float:
+    if has_structured_article_ref:
+        return 0.98
     if article_refs:
         return 0.95
     if law_name in matched_law_names:
         return 0.85
     return 0.65
+
+
+def _merge_article_refs(
+    parsed: dict[str, Any],
+    body_text: str,
+    family_law_names: list[str],
+) -> dict[str, list[dict[str, Any]]]:
+    merged: dict[str, list[dict[str, Any]]] = {}
+
+    for item in parsed.get("structured_article_refs") or []:
+        if not isinstance(item, dict):
+            continue
+        law_name = str(item.get("law_name") or "").strip()
+        article_key = str(item.get("article_key") or "").strip()
+        article_no_display = str(item.get("article_no_display") or "").strip()
+        if not law_name or not article_key or not article_no_display:
+            continue
+        merged.setdefault(law_name, [])
+        article = {
+            "article_key": article_key,
+            "article_no_display": article_no_display,
+            "reference_sources": ["structured_field"],
+        }
+        if not any(
+            existing["article_key"] == article["article_key"]
+            and existing["article_no_display"] == article["article_no_display"]
+            for existing in merged[law_name]
+        ):
+            merged[law_name].append(article)
+
+    body_refs_map = extract_explicit_article_refs(body_text, family_law_names) if body_text else {}
+    for law_name, refs in body_refs_map.items():
+        merged.setdefault(law_name, [])
+        for article in refs:
+            existing = next(
+                (
+                    item
+                    for item in merged[law_name]
+                    if item["article_key"] == article["article_key"]
+                    and item["article_no_display"] == article["article_no_display"]
+                ),
+                None,
+            )
+            if existing is None:
+                merged[law_name].append(
+                    {
+                        **article,
+                        "reference_sources": ["body_regex"],
+                    }
+                )
+                continue
+            if "body_regex" not in existing["reference_sources"]:
+                existing["reference_sources"].append("body_regex")
+
+    return merged
 
 
 
@@ -212,6 +273,8 @@ def build_root_relation_payloads(
         payload = _load_detail_payload(canonical_row or {})
         parsed = parse_case_payload(target, payload or {}, fallback=canonical_row or hits[0])
         body_text = str(parsed.get("body_text") or "").strip()
+        if str(parsed.get("body_type") or "").strip() == "image_only":
+            body_text = ""
 
         family_law_names = sorted(
             {
@@ -221,8 +284,13 @@ def build_root_relation_payloads(
             }
         )
         matched_law_names = find_related_law_names(body_text, family_law_names) if body_text else []
-        article_refs_map = extract_explicit_article_refs(body_text, family_law_names) if body_text else {}
+        article_refs_map = _merge_article_refs(parsed, body_text, family_law_names)
         article_refs = article_refs_map.get(law_name, [])
+        has_structured_article_ref = any(
+            str(item.get("law_name") or "").strip() == law_name
+            for item in (parsed.get("structured_article_refs") or [])
+            if isinstance(item, dict)
+        )
         referenced_case_numbers = (
             extract_case_number_refs(body_text, exclude_numbers=[parsed.get("doc_number")])
             if body_text and "cited_case" in relation_rules
@@ -235,12 +303,21 @@ def build_root_relation_payloads(
         if article_refs and "related_law" in relation_rules:
             relation_types.append("related_law")
 
+        body_verified = bool(law_name in matched_law_names or article_refs or has_structured_article_ref)
         relation_types = list(dict.fromkeys(relation_types))
         source_law_uid = str(hits[0].get("source_law_uid") or build_law_uid(None, None, law_name))
         preview_anchor = law_name if law_name in matched_law_names else (referenced_case_numbers[0] if referenced_case_numbers else None)
         evidence_preview = build_evidence_preview(body_text, law_name=law_name, anchor=preview_anchor)
         article_keys = [item["article_key"] for item in article_refs]
         article_no_displays = [item["article_no_display"] for item in article_refs]
+        article_reference_sources = sorted(
+            {
+                source
+                for item in article_refs
+                for source in (item.get("reference_sources") or [])
+                if str(source).strip()
+            }
+        )
         source_file_paths = sorted(
             {
                 str(hit.get("source_file_path") or "").strip()
@@ -276,7 +353,9 @@ def build_root_relation_payloads(
             "relation_types": relation_types,
             "article_keys": article_keys,
             "article_no_displays": article_no_displays,
-            "relation_confidence": _confidence(article_refs, matched_law_names, law_name),
+            "article_reference_sources": article_reference_sources,
+            "body_verified": body_verified,
+            "relation_confidence": _confidence(article_refs, matched_law_names, law_name, has_structured_article_ref) if body_verified else 0.45,
             "evidence_preview": evidence_preview,
             "display_text": _display_text(evidence_preview or body_text),
             "source_hit_count": len(hits),
@@ -332,6 +411,8 @@ def _merge_relation_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
             dict.fromkeys(list(current.get("_referenced_case_numbers", [])) + list(row.get("_referenced_case_numbers", [])))
         )
         current["relation_confidence"] = max(float(current.get("relation_confidence") or 0), float(row.get("relation_confidence") or 0))
+        if row.get("body_verified") is True:
+            current["body_verified"] = True
         if not current.get("evidence_preview") and row.get("evidence_preview"):
             current["evidence_preview"] = row.get("evidence_preview")
         if not current.get("source_file_path") and row.get("source_file_path"):
@@ -356,6 +437,77 @@ def _merge_relation_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     results.sort(key=lambda row: str(row.get("id") or ""))
     return results
 
+
+
+_LAW_LEVEL_RANK = {"법": 0, "시행령": 1, "시행규칙": 2}
+
+
+def _is_unverified_search_hit(row: dict[str, Any]) -> bool:
+    """body 미검증 search_hit-only law_to_case row 판별.
+
+    제거 기준:
+      - relation_model == "law_to_case"
+      - body_verified이 True가 아님 (False 또는 필드 없음 — legacy expanded row 포함)
+      - relation_types == ["search_hit"]
+
+    보조 검증: 위 조건이 참이면 confidence가 0.45여야 한다.
+    그렇지 않으면 confidence 체계 변경 가능성이 있으므로 경고를 남긴다.
+    """
+    if row.get("relation_model") != "law_to_case":
+        return False
+    if row.get("body_verified") is True:
+        return False
+    types = list(row.get("relation_types") or [])
+    if types != ["search_hit"]:
+        return False
+    conf = row.get("relation_confidence")
+    if conf != 0.45:
+        logger.warning(
+            "unverified search_hit row with unexpected confidence %s: %s",
+            conf,
+            row.get("id"),
+        )
+    return True
+
+
+def _classify_law_level(law_name: str | None) -> str:
+    name = str(law_name or "")
+    if "시행규칙" in name:
+        return "시행규칙"
+    if "시행령" in name:
+        return "시행령"
+    return "법"
+
+
+def _dedup_family_search_hits(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """search_hit만 가진 레코드 중 법령 패밀리 중복을 제거한다.
+
+    같은 (canonical_case_id, root_law_uid) 내에서 cited_law/related_law가 있는
+    법령은 유지하고, search_hit만 있는 법령 중 최상위(법>시행령>시행규칙)만 남긴다.
+    """
+    keep: list[dict[str, Any]] = []
+    search_hit_only: dict[tuple[str, str], list[dict[str, Any]]] = {}
+
+    for row in rows:
+        types = row.get("relation_types") or []
+        has_strong = any(t in types for t in ("cited_law", "related_law"))
+        if has_strong or row.get("relation_model") != "law_to_case":
+            keep.append(row)
+            continue
+        case_id = str(row.get("canonical_case_id") or row.get("canonical_id") or "").strip()
+        root_uid = str(row.get("root_law_uid") or "").strip()
+        key = (case_id, root_uid)
+        search_hit_only.setdefault(key, []).append(row)
+
+    for group_rows in search_hit_only.values():
+        if len(group_rows) <= 1:
+            keep.extend(group_rows)
+            continue
+        group_rows.sort(key=lambda r: _LAW_LEVEL_RANK.get(_classify_law_level(r.get("source_law_name")), 99))
+        keep.append(group_rows[0])
+
+    keep.sort(key=lambda r: str(r.get("id") or ""))
+    return keep
 
 
 def build_legal_relation_records(
@@ -385,7 +537,8 @@ def build_legal_relation_records(
                     )
                 )
 
-            return _merge_relation_rows(built_rows)
+            result = _dedup_family_search_hits(_merge_relation_rows(built_rows))
+            return [r for r in result if not _is_unverified_search_hit(r)]
 
     expanded_dir = Path(expanded_base_dir)
     if raw_related_base_dir is not None and expanded_dir == Path("data/expanded/03_expanded_related_docs"):
@@ -396,7 +549,8 @@ def build_legal_relation_records(
     for path in sorted(expanded_dir.rglob("relation_records.jsonl")):
         rows.extend(list(_iter_jsonl(path)))
     if rows:
-        return _merge_relation_rows(rows)
+        result = _merge_relation_rows(rows)
+        return [r for r in result if not _is_unverified_search_hit(r)]
 
     return []
 

--- a/apps/backend/law-updater/src/parser/legal_case_parser.py
+++ b/apps/backend/law-updater/src/parser/legal_case_parser.py
@@ -497,3 +497,22 @@ def build_evidence_preview(
     start = max(0, idx - 40)
     end = min(len(normalized_text), idx + limit)
     return normalized_text[start:end].strip()
+
+
+_DETC_CASE_TYPE_TOKENS = {"헌가", "헌나", "헌다", "헌라", "헌마", "헌바", "헌사", "헌아"}
+
+
+def classify_case_type_from_number(case_number: str) -> str | None:
+    """사건번호에서 사례 유형(prec/detc)을 분류한다.
+
+    헌[가나다라마바사아] → "detc", 기타 유효 토큰 → "prec", 그 외 → None.
+    """
+    match = re.fullmatch(r"(\d{2,4})([가-힣]{1,4})(\d{1,8})", str(case_number or "").strip())
+    if not match:
+        return None
+    token = match.group(2)
+    if token in _DETC_CASE_TYPE_TOKENS:
+        return "detc"
+    if token in ALLOWED_CASE_TYPE_TOKENS:
+        return "prec"
+    return None

--- a/apps/backend/legal-pipeline/scripts/sync_law_updater.sh
+++ b/apps/backend/legal-pipeline/scripts/sync_law_updater.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# legal-pipeline/src/export → law-updater/src/export 동기화
+# 실행: bash scripts/sync_law_updater.sh (repo 루트 또는 legal-pipeline 루트 어디서든 가능)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+SRC="$REPO_ROOT/apps/backend/legal-pipeline/src/export"
+DST="$REPO_ROOT/apps/backend/law-updater/src/export"
+
+FILES=(
+  legal_case_dataset_builder.py
+  legal_case_relation_builder.py
+  dataset_builder.py
+  legal_relation_builder.py
+)
+
+echo "=== law-updater 동기화 시작 ==="
+for f in "${FILES[@]}"; do
+  cp "$SRC/$f" "$DST/$f"
+  echo "synced: $f"
+done
+
+echo ""
+echo "=== diff 결과 (차이 없으면 정상) ==="
+for f in "${FILES[@]}"; do
+  diff "$SRC/$f" "$DST/$f" && echo "$f: identical" || echo "$f: DIFF 존재"
+done

--- a/apps/backend/legal-pipeline/src/export/legal_relation_builder.py
+++ b/apps/backend/legal-pipeline/src/export/legal_relation_builder.py
@@ -496,7 +496,8 @@ def _dedup_family_search_hits(rows: list[dict[str, Any]]) -> list[dict[str, Any]
             continue
         case_id = str(row.get("canonical_case_id") or row.get("canonical_id") or "").strip()
         root_uid = str(row.get("root_law_uid") or "").strip()
-        key = (case_id, root_uid)
+        root_law_name = str(row.get("root_law_name") or "").strip()
+        key = (case_id, root_uid if root_uid else root_law_name)
         search_hit_only.setdefault(key, []).append(row)
 
     for group_rows in search_hit_only.values():


### PR DESCRIPTION
## Work Description
- 미반영 된 legal-pipeline 코드를 law-updater 에 반영
- apps/backend/legal-pipeline/script/sync_law_updater.sh 를 통해 export / 동기화 
- 증분 실행시 발생 가능한 누락 및 relation 오염 위험 제거

## Changes
### 동기화 및 수정
- apps/backend/law-updater/src/export/dataset_builder.py 
- apps/backend/law-updater/src/export/legal_case_dataset_builder.py
- apps/backend/law-updater/src/export/legal_case_relation_builder.py : case-to-cas
- apps/backend/law-updater/src/export/legal_relation_builder.py 
- aapps/backend/law-updater/src/parser/legal_case_parser.py

### legal-pipeine 수정 및 스크립트 파일추가 
- apps/backend/legal-pipeline/scripts/sync_law_updater.sh
- apps/backend/legal-pipeline/src/export/legal_relation_builder.py

## Testing
- [x] import 정상 작동 확인
- [x] 증분 파잎라인 end-to-end 로컬실행

## Related Issue
close #164
