### PR TITLE
[Refactor] backend-api / neo4j 연결

### DIFF
--- a/apps/backend/api/src/dependencies.py
+++ b/apps/backend/api/src/dependencies.py
@@ -17,6 +17,8 @@
 
 from functools import lru_cache
 
+from httpx import get
+
 from rag_pipeline.generation.pipeline import RagPipeline
 from rag_pipeline.generation.service import GenerationService
 from rag_pipeline.query_parser import QueryParser
@@ -74,7 +76,10 @@ def warmup_dependencies() -> None:
     get_rag_pipeline()
     get_query_parser()
     get_generation_service()
+    get_cypher_planner()
 
+    neo4j = get_neo4j_client()
+    neo4j.verify_connectivity()
 
 def reset_dependency_caches() -> None:
     """테스트/로컬 디버깅용 캐시 초기화 유틸리티."""

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -38,6 +38,11 @@ OPENSEARCH_API_KEY=
 OPENSEARCH_USERNAME=
 OPENSEARCH_PASSWORD=
 
+# neo4j - if running in same Compose stack, prefer service name over localhost
+NEO4J_URI=bolt://neo4j:7687
+NEO4J_USERNAME=neo4j
+NEO4J_PASSWORD=password
+
 # Query Parser (법령명/조문번호 추출 LLM)
 # 생략 시 GEMINI_MODEL → gemini-2.0-flash-lite 순으로 fallback
 QUERY_PARSER_MODEL=gemini-2.5-flash-lite

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -28,6 +28,9 @@ services:
       - QUERY_PARSER_MODEL=${QUERY_PARSER_MODEL:-}
       - QUERY_PARSER_TIMEOUT=${QUERY_PARSER_TIMEOUT:-10}
       - QUERY_PARSER_STRICT=${QUERY_PARSER_STRICT:-false}
+      - NEO4J_URI=${NEO4J_URI:-bolt://neo4j:7687}
+      - NEO4J_USER=${NEO4J_USER:-neo4j}
+      - NEO4J_PASSWORD=${NEO4J_PASSWORD:-}
       - QDRANT_URL=${QDRANT_URL:-http://qdrant:6333}
       - QDRANT_COLLECTIONS=${QDRANT_COLLECTIONS:-law_article,legal_case,legal_relation}
       - QDRANT_API_KEY=${QDRANT_API_KEY:-}


### PR DESCRIPTION
## Work Description
- Backend API 에서 /api/v1/grpah/query  운영 기능으로 사용할 수 있도록 보강
- 후속 작업, 프론트 그래프 랜더링 구현 전 동작 오류 방지 위해 수정

## Changes
- warmup_dependencies()에 graph 관련 의존성 초기화를 포함
    - CypherPlanner
    - Neo4jClient
    - Neo4jClient.verify_connectivity()
 - Coolify 배포용 backend-api 환경변수에 Neo4j 연결값을 추가
    - NEO4J_URI
    - NEO4J_USER
    - NEO4J_PASSWORD
### 배포 전(merge 전 확인)  
- 환경 변수 coolify 추가 
 ```env
  NEO4J_URI=bolt://<neo4j-host>:7687
  NEO4J_USER=neo4j
  NEO4J_PASSWORD=<password>
```

## Related Issue
- 없음