### PR TITLE
[Refactor] NL2Cypher : LLM 슬롯추출에서 LLM 자유생성으로 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -233,7 +233,7 @@ apps/backend/doc-processor/tests/python-hwpx-docs/
 apps/backend/legal-pipeline/data/
 apps/backend/legal-pipeline/.local/
 apps/backend/legal-pipeline/CODEX.md
-apps/backend/legal-pipeline/scripts/experiment1_*.py
+apps/backend/legal-pipeline/scripts/experiment*.py
 
 # rag
 apps/backend/rag/docs/

--- a/apps/backend/api/.env.example
+++ b/apps/backend/api/.env.example
@@ -13,6 +13,12 @@ NEO4J_URI=bolt://localhost:7687
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=
 
+# NL2Cypher 방식 선택 (template | llm_free | llm_free_with_template_fallback)
+# template: 슬롯 추출 + 고정 템플릿 (방식 A, 기본)
+# llm_free: LLM 자유 Cypher 생성 (방식 B, 권장)
+# llm_free_with_template_fallback: 방식 B 실패 시 방식 A 자동 fallback
+GRAPH_QUERY_MODE=llm_free
+
 # Embeddings (API only)
 EMBEDDING_MODEL=text-embedding-3-large
 OPENAI_API_KEY=

--- a/apps/backend/api/src/dependencies.py
+++ b/apps/backend/api/src/dependencies.py
@@ -15,6 +15,7 @@
       ...
 """
 
+import os
 from functools import lru_cache
 
 from httpx import get
@@ -24,6 +25,10 @@ from rag_pipeline.generation.service import GenerationService
 from rag_pipeline.query_parser import QueryParser
 from rag_pipeline.graph.neo4j_client import Neo4jClient
 from rag_pipeline.graph.cypher_planner import CypherPlanner
+from rag_pipeline.graph.llm_cypher_planner import (
+    LlmCypherPlanner,
+    LlmCypherPlannerWithFallback,
+)
 
 
 @lru_cache(maxsize=1)
@@ -63,8 +68,18 @@ def get_neo4j_client() -> Neo4jClient:
 
 
 @lru_cache(maxsize=1)
-def get_cypher_planner() -> CypherPlanner:
-    """환경변수 기반으로 CypherPlanner 인스턴스를 반환한다."""
+def get_cypher_planner() -> CypherPlanner | LlmCypherPlanner | LlmCypherPlannerWithFallback:
+    """GRAPH_QUERY_MODE 환경변수에 따라 방식 A/B를 선택한다.
+
+    template (기본)                   → CypherPlanner (방식 A)
+    llm_free                          → LlmCypherPlanner (방식 B)
+    llm_free_with_template_fallback   → LlmCypherPlannerWithFallback (B → A)
+    """
+    mode = os.getenv("GRAPH_QUERY_MODE", "template").strip().lower()
+    if mode == "llm_free":
+        return LlmCypherPlanner.from_env()
+    if mode == "llm_free_with_template_fallback":
+        return LlmCypherPlannerWithFallback.from_env()
     return CypherPlanner.from_env()
 
 

--- a/apps/backend/rag/rag_pipeline/graph/llm_cypher_planner.py
+++ b/apps/backend/rag/rag_pipeline/graph/llm_cypher_planner.py
@@ -1,0 +1,276 @@
+"""NL2Cypher 방식 B — LLM 자유 Cypher 생성.
+
+CypherGuard로 injection 방어 후 Neo4j에 실행한다.
+기존 CypherPlanner(방식 A)와 동일한 CypherPlan 인터페이스를 구현하므로
+graph.py 라우터 변경 없이 GRAPH_QUERY_MODE env 스위칭이 가능하다.
+
+GRAPH_QUERY_MODE:
+  "template"                        → CypherPlanner (방식 A, 기본)
+  "llm_free"                        → LlmCypherPlanner (방식 B)
+  "llm_free_with_template_fallback" → LlmCypherPlannerWithFallback (B → A)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from .cypher_planner import (
+    CypherPlan,
+    CypherPlanner,
+    GraphQuerySlots,
+    _extract_json,
+)
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MODEL = "gemini-1.5-flash"
+_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/models"
+
+# ── CypherGuard ───────────────────────────────────────────────────────────────
+
+_FORBIDDEN_KEYWORDS = frozenset({
+    "CREATE", "MERGE", "SET", "DELETE", "DETACH",
+    "DROP", "CALL", "LOAD", "APOC",
+})
+_FORBIDDEN_PATTERNS = [re.compile(r"\bUNION\b", re.IGNORECASE)]
+_ALLOWED_RELS = frozenset({
+    "HAS_ARTICLE", "HAS_CHILD_LAW", "DELEGATES_TO_LAW",
+    "REFERS_TO_LAW", "REFERS_TO_ARTICLE",
+})
+_REL_RE = re.compile(r"\[:(\w+)\]")
+
+
+class CypherGuardError(ValueError):
+    pass
+
+
+class CypherGuard:
+    """실행 전 Cypher 안전성 검증 (injection/allowlist)."""
+
+    @staticmethod
+    def validate(cypher: str) -> None:
+        upper = cypher.upper()
+        for kw in _FORBIDDEN_KEYWORDS:
+            if re.search(rf"\b{kw}\b", upper):
+                raise CypherGuardError(f"forbidden keyword: {kw}")
+        for pat in _FORBIDDEN_PATTERNS:
+            if pat.search(cypher):
+                raise CypherGuardError("UNION is not allowed")
+        for rel in _REL_RE.findall(cypher):
+            if rel.upper() not in _ALLOWED_RELS:
+                raise CypherGuardError(f"forbidden relationship type: {rel}")
+        if "MATCH" not in upper:
+            raise CypherGuardError("query must contain at least one MATCH clause")
+
+
+# ── 시스템 프롬프트 ────────────────────────────────────────────────────────────
+
+_SYSTEM_PROMPT = """\
+당신은 Neo4j Cypher 전문가입니다.
+아래 스키마에서 자연어 질의에 맞는 Cypher를 생성하세요.
+
+스키마:
+  노드: Law(law_uid, law_name), Article(article_uid, article_no)
+  관계:
+    (Law)-[:HAS_ARTICLE]->(Article)
+    (Law)-[:HAS_CHILD_LAW]->(Law)
+    (Law)-[:DELEGATES_TO_LAW]->(Law)
+    (Law)-[:REFERS_TO_LAW]->(Law)
+    (Article)-[:REFERS_TO_ARTICLE]->(Article)
+
+규칙:
+  - MATCH/OPTIONAL MATCH/WHERE/RETURN/ORDER BY/LIMIT/WITH만 허용
+  - CREATE/MERGE/SET/DELETE/DETACH/DROP/CALL/LOAD/UNION/apoc.* 절대 금지
+  - 파라미터는 반드시 $law_name, $article_no 형식 사용 (값 직접 삽입 금지)
+  - 반드시 아래 JSON 형식만 출력 (설명/코드블록/마크다운 금지):
+    {"cypher": "...", "params": {"law_name": "..."}}
+
+relation_type별 필수 RETURN alias:
+  child_law:  child_law_name, child_law_uid, classified_level
+  delegation: target_law_name, target_law_uid
+  reference(법→법): ref_type(='law'), ref_name, ref_uid, ref_article_no(=null)
+  reference(조문):  ref_type(='article'), ref_article_no, ref_uid, ref_name
+  structure:  article_no, article_uid
+"""
+
+_FEW_SHOT = [
+    (
+        "근로기준법의 하위법령은 무엇인가요?",
+        '{"cypher": "MATCH (parent:Law {law_name: $law_name})-[:HAS_CHILD_LAW]->(child:Law) RETURN child.law_name AS child_law_name, child.law_uid AS child_law_uid, child.classified_level AS classified_level ORDER BY child.law_name", "params": {"law_name": "근로기준법"}}',
+    ),
+    (
+        "산업안전보건법 시행령과 시행규칙을 알려주세요.",
+        '{"cypher": "MATCH (parent:Law {law_name: $law_name})-[:HAS_CHILD_LAW]->(child:Law) RETURN child.law_name AS child_law_name, child.law_uid AS child_law_uid, child.classified_level AS classified_level ORDER BY child.law_name", "params": {"law_name": "산업안전보건법"}}',
+    ),
+    (
+        "산업안전보건법이 위임하는 법령을 알려주세요.",
+        '{"cypher": "MATCH (source:Law {law_name: $law_name})-[:DELEGATES_TO_LAW]->(target:Law) RETURN target.law_name AS target_law_name, target.law_uid AS target_law_uid ORDER BY target.law_name", "params": {"law_name": "산업안전보건법"}}',
+    ),
+    (
+        "최저임금법이 시행령에 위임하는 내용을 알려주세요.",
+        '{"cypher": "MATCH (source:Law {law_name: $law_name})-[:DELEGATES_TO_LAW]->(target:Law) RETURN target.law_name AS target_law_name, target.law_uid AS target_law_uid ORDER BY target.law_name", "params": {"law_name": "최저임금법"}}',
+    ),
+    (
+        "근로기준법이 참조하는 다른 법령은 무엇인가요?",
+        r"""{"cypher": "MATCH (source:Law {law_name: $law_name})-[:REFERS_TO_LAW]->(target:Law) RETURN 'law' AS ref_type, target.law_name AS ref_name, target.law_uid AS ref_uid, null AS ref_article_no ORDER BY target.law_name", "params": {"law_name": "근로기준법"}}""",
+    ),
+    (
+        "최저임금법이 다른 법령을 참조하는 경우를 알려주세요.",
+        r"""{"cypher": "MATCH (source:Law {law_name: $law_name})-[:REFERS_TO_LAW]->(target:Law) RETURN 'law' AS ref_type, target.law_name AS ref_name, target.law_uid AS ref_uid, null AS ref_article_no ORDER BY target.law_name", "params": {"law_name": "최저임금법"}}""",
+    ),
+    (
+        "하도급거래 공정화에 관한 법률 제2조가 참조하는 조문은?",
+        r"""{"cypher": "MATCH (law:Law {law_name: $law_name})-[:HAS_ARTICLE]->(src:Article {article_no: $article_no}) MATCH (src)-[:REFERS_TO_ARTICLE]->(tgt:Article) MATCH (tgt_law:Law)-[:HAS_ARTICLE]->(tgt) RETURN 'article' AS ref_type, tgt.article_no AS ref_article_no, tgt.article_uid AS ref_uid, tgt_law.law_name AS ref_name ORDER BY tgt_law.law_name, tgt.article_no", "params": {"law_name": "하도급거래 공정화에 관한 법률", "article_no": "제2조"}}""",
+    ),
+    (
+        "근로기준법의 조문 구조를 보여주세요.",
+        r"""{"cypher": "MATCH (law:Law {law_name: $law_name})-[:HAS_ARTICLE]->(article:Article) RETURN article.article_no AS article_no, article.article_uid AS article_uid ORDER BY toInteger(split(replace(article.article_no, '제', ''), '조')[0]), article.article_no", "params": {"law_name": "근로기준법"}}""",
+    ),
+]
+
+
+def _build_prompt(query: str) -> str:
+    lines: list[str] = []
+    for q, expected in _FEW_SHOT:
+        lines.append(f"질문: {q}")
+        lines.append(f"출력: {expected}")
+        lines.append("")
+    lines.append(f"질문: {query}")
+    lines.append("출력:")
+    return "\n".join(lines)
+
+
+def _infer_relation_type(cypher: str) -> str | None:
+    upper = cypher.upper()
+    if "HAS_CHILD_LAW" in upper:
+        return "child_law"
+    if "DELEGATES_TO_LAW" in upper:
+        return "delegation"
+    if "REFERS_TO" in upper:
+        return "reference"
+    if "HAS_ARTICLE" in upper:
+        return "structure"
+    return None
+
+
+# ── LlmCypherPlannerConfig ────────────────────────────────────────────────────
+
+@dataclass
+class LlmCypherPlannerConfig:
+    api_key: str
+    model: str = _DEFAULT_MODEL
+    timeout: int = 15
+    max_tokens: int = 2048
+    temperature: float = 0.0
+
+    @property
+    def url(self) -> str:
+        return f"{_GEMINI_BASE_URL}/{self.model}:generateContent"
+
+    @classmethod
+    def from_env(cls) -> "LlmCypherPlannerConfig":
+        model = (
+            os.getenv("QUERY_PARSER_MODEL", "").strip()
+            or os.getenv("GEMINI_MODEL", "").strip()
+            or _DEFAULT_MODEL
+        )
+        api_key = os.getenv("GEMINI_API_KEY", "").strip()
+        timeout = int(os.getenv("QUERY_PARSER_TIMEOUT", "15").strip() or "15")
+        return cls(api_key=api_key, model=model, timeout=timeout)
+
+
+# ── LlmCypherPlanner ─────────────────────────────────────────────────────────
+
+class LlmCypherPlanner:
+    """LLM이 Cypher를 직접 생성하는 방식 B.
+
+    인터페이스는 CypherPlanner와 동일(plan() → CypherPlan | None)하므로
+    graph.py 라우터 변경 없이 GRAPH_QUERY_MODE env로 전환 가능하다.
+    """
+
+    def __init__(self, config: LlmCypherPlannerConfig) -> None:
+        self._cfg = config
+
+    @classmethod
+    def from_env(cls) -> "LlmCypherPlanner":
+        return cls(LlmCypherPlannerConfig.from_env())
+
+    def plan(self, query: str) -> CypherPlan | None:
+        from ..generation.llm_client import generate_answer
+
+        if not self._cfg.api_key:
+            logger.warning("llm_cypher_planner: GEMINI_API_KEY 미설정, 건너뜀")
+            return None
+
+        raw_text = ""
+        try:
+            raw_text, _ = generate_answer(
+                _build_prompt(query),
+                provider="gemini",
+                url=self._cfg.url,
+                model=self._cfg.model,
+                api_key=self._cfg.api_key,
+                timeout=self._cfg.timeout,
+                max_tokens=self._cfg.max_tokens,
+                temperature=self._cfg.temperature,
+                system_prompt=_SYSTEM_PROMPT,
+                response_mime_type="application/json",
+            )
+
+            data = _extract_json(raw_text)
+            cypher: str = data.get("cypher", "").strip()
+            params: dict[str, Any] = data.get("params", {})
+
+            if not cypher:
+                logger.warning("llm_cypher_planner: 빈 Cypher — raw=%r", raw_text[:200])
+                return None
+
+            CypherGuard.validate(cypher)
+
+            relation_type = _infer_relation_type(cypher)
+            if not relation_type:
+                logger.warning("llm_cypher_planner: relation_type 추론 실패 — cypher=%r", cypher[:120])
+                return None
+
+            slots = GraphQuerySlots(
+                law_name=params.get("law_name") or None,
+                article_no=params.get("article_no") or None,
+                relation_type=relation_type,
+            )
+            logger.debug("llm_cypher_planner: query=%r slots=%s", query[:80], slots)
+            return CypherPlan(cypher=cypher, params=params, relation_type=relation_type, slots=slots)
+
+        except CypherGuardError as exc:
+            logger.warning("llm_cypher_planner: CypherGuard 차단: %s", exc)
+            return None
+        except Exception as exc:
+            logger.warning("llm_cypher_planner: 실패: %s | raw=%r", exc, raw_text[:200] or "N/A")
+            return None
+
+
+# ── LlmCypherPlannerWithFallback ──────────────────────────────────────────────
+
+class LlmCypherPlannerWithFallback:
+    """방식 B 시도 후 None이면 방식 A(CypherPlanner)로 fallback."""
+
+    def __init__(self, llm: LlmCypherPlanner, template: CypherPlanner) -> None:
+        self._llm = llm
+        self._template = template
+
+    @classmethod
+    def from_env(cls) -> "LlmCypherPlannerWithFallback":
+        return cls(
+            llm=LlmCypherPlanner.from_env(),
+            template=CypherPlanner.from_env(),
+        )
+
+    def plan(self, query: str) -> CypherPlan | None:
+        result = self._llm.plan(query)
+        if result is not None:
+            return result
+        logger.debug("llm_cypher_planner: B 실패 → CypherPlanner(A) fallback")
+        return self._template.plan(query)

--- a/apps/backend/rag/rag_pipeline/graph/llm_cypher_planner.py
+++ b/apps/backend/rag/rag_pipeline/graph/llm_cypher_planner.py
@@ -34,14 +34,15 @@ _GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/models"
 
 _FORBIDDEN_KEYWORDS = frozenset({
     "CREATE", "MERGE", "SET", "DELETE", "DETACH",
-    "DROP", "CALL", "LOAD", "APOC",
+    "DROP", "CALL", "LOAD", "APOC", "REMOVE",  # REMOVE 추가 (P1)
 })
 _FORBIDDEN_PATTERNS = [re.compile(r"\bUNION\b", re.IGNORECASE)]
 _ALLOWED_RELS = frozenset({
     "HAS_ARTICLE", "HAS_CHILD_LAW", "DELEGATES_TO_LAW",
     "REFERS_TO_LAW", "REFERS_TO_ARTICLE",
 })
-_REL_RE = re.compile(r"\[:(\w+)\]")
+# `[:TYPE]` 및 `[r:TYPE]`, `[r:TYPE*]` 등 변수·범위 포함 패턴 모두 캡처 (P1)
+_REL_RE = re.compile(r"\[(?:\w+\s*:\s*|:)(\w+)")
 
 
 class CypherGuardError(ValueError):

--- a/apps/backend/rag/rag_pipeline/graph/llm_cypher_planner.py
+++ b/apps/backend/rag/rag_pipeline/graph/llm_cypher_planner.py
@@ -206,6 +206,13 @@ class LlmCypherPlanner:
             logger.warning("llm_cypher_planner: GEMINI_API_KEY 미설정, 건너뜀")
             return None
 
+        # LLM 호출 전 사전 필터 — 쿼리에 금지 키워드가 직접 포함된 경우 즉시 차단
+        query_upper = query.upper()
+        for kw in _FORBIDDEN_KEYWORDS:
+            if re.search(rf"\b{kw}\b", query_upper):
+                logger.warning("llm_cypher_planner: pre-filter 차단 (keyword=%s)", kw)
+                return None
+
         raw_text = ""
         try:
             raw_text, _ = generate_answer(

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -43,6 +43,9 @@ NEO4J_URI=bolt://neo4j:7687
 NEO4J_USERNAME=neo4j
 NEO4J_PASSWORD=password
 
+# NL2Cypher (template | llm_free | llm_free_with_template_fallback)
+GRAPH_QUERY_MODE=llm_free
+
 # Query Parser (법령명/조문번호 추출 LLM)
 # 생략 시 GEMINI_MODEL → gemini-2.0-flash-lite 순으로 fallback
 QUERY_PARSER_MODEL=gemini-2.5-flash-lite


### PR DESCRIPTION
## Work Description
- 기존 NL2Cypher 방식 슬롯 추출 + 고정템플릿 단순한 구조 질문도 성공률 40% 
- 위 문제해결 위해 LLM 자유생성으로 변경 
- 자유생성 ijection 방식 보안 레이어 추가 
- apps/backend/api   GRAPH_QUERY_MODE 환경변수로 방식 지정가능(슬로추출/LLM생성)

## Changes
### 1. 변경파일
- rag/rag_pipeline/graph/llm_cypher_planner.py
  -  신규추가
  - NL2Cyper 방식 및 보안레이어
- api/src/dependencies.py
  - env 값 기반 분기 추가  
- api/.env.example
  - GRAPH_QUERY_MODE 환경변수 추가 
 -  .gitignore
   - NL2Cyper test 코드 제외 추가

### 2. 구현사항
- 보안 검증 레이어
  - CypherGuard — 보안 검증 레이어 : 금지키워드, 금지패턴, 관계허용목록, 필수조건, 정규식 개선  
  - CypherGuard — 보안 검증 레이어를 per-filter 로 LLM 호출 전에 차단
- GRAPH_QUERY_MODE 분기
  - template → CypherPlanner (방식 A, 슬롯 추출 + 고정 템플릿)
  - llm_free → LlmCypherPlanner (방식 B, LLM 자유 Cypher 생성) ← 권장
  - llm_free_with_template_fallback → 방식 B 실패 시 방식 A 자동 fallback
- NL2Cyper test 결과(법령간 참조, 위임, 하위 관계 및 ingection)
  - 전체 성공 90%
  - relaiton_type  및 law_name 정확도 : 100%
  - forbidden_blocked : 삭제 유도 프롬프트 차단 

### 3. 로컬 실행 확인사항
- API 환경변수 추가
  - GRAPH_QUERY_MODE=llm_free
 
### 4. Coolify/ 확인사항
- API 환경변수 추가
  - GRAPH_QUERY_MODE=llm_free
- API 서비스 재시작

### 5. 한계점
- 법령명 + 관계, 위임, 하위 질문은 성공률은 증가했으나 조문간 질의는 여전히 성공률 낮음

### 추가
- GRAPH_QUERY_MODE=llm_free 없어도 오류X
- os.getenv("GRAPH_QUERY_MODE", "template")으로 기본값이 "template"이라 env 없으면 기존방식으로 작동

## Testing
- [x] 빌드 오류 테스트
- [x] 로멀 테스트
- [x] NL2Cyper  테스트

## Related Issue
close #173
