### PR TITLE
[Refactor] law_article 데이터 품질 개선

### DIFF
--- a/apps/backend/legal-pipeline/src/export/dataset_builder.py
+++ b/apps/backend/legal-pipeline/src/export/dataset_builder.py
@@ -636,7 +636,7 @@ def _normalize_law_meta(parsed_law: dict[str, Any]) -> tuple[str | None, str]:
     return kind_name, classified_level
 
 
-_DELETED_ARTICLE_RE = re.compile(r"제\d[\d의]*조\s+삭제\s*<", re.UNICODE)
+_DELETED_ARTICLE_RE = re.compile(r"제\d+(?:조의\d+|조)\s+삭제", re.UNICODE)
 
 
 def _is_header_only_supplementary(text: str) -> bool:

--- a/apps/backend/legal-pipeline/src/export/dataset_builder.py
+++ b/apps/backend/legal-pipeline/src/export/dataset_builder.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import re
 from datetime import UTC, datetime
 from pathlib import Path
@@ -96,7 +97,11 @@ def _dedup_texts(texts: list[str]) -> list[str]:
     return results
 
 
+_IMG_TAG_RE = re.compile(r"<img[^>]*/?>", re.IGNORECASE)
+
+
 def _normalize_law_text(text: str, *, preserve_structure: bool) -> str:
+    text = _IMG_TAG_RE.sub("", text).strip()
     return _normalize_structure(text) if preserve_structure else _normalize_space(text)
 
 
@@ -533,6 +538,26 @@ def _build_law_article_text(
     return "\n".join(line for line in lines if line).strip()
 
 
+def _parse_raw_list_text(text: str) -> str:
+    """normalized JSON에 '[[\\'...\\']]' 형태로 baked-in된 부칙 텍스트를 정상 텍스트로 변환."""
+    stripped = text.strip()
+    if not (stripped.startswith("[[") or stripped.startswith("['")):
+        return text
+    try:
+        parsed = ast.literal_eval(stripped)
+        if isinstance(parsed, list):
+            lines = []
+            for item in parsed:
+                if isinstance(item, list):
+                    lines.extend(str(x).strip() for x in item if x)
+                elif item:
+                    lines.append(str(item).strip())
+            return "\n".join(lines)
+    except (ValueError, SyntaxError):
+        pass
+    return text
+
+
 def _build_supplementary_text(
     parsed_law: dict[str, Any],
     supplementary: dict[str, Any],
@@ -564,7 +589,7 @@ def _build_supplementary_text(
     if number:
         lines.append(f"부칙번호: {number}")
     if text:
-        lines.append(text)
+        lines.append(_parse_raw_list_text(text))
 
     return "\n".join(line for line in lines if line).strip()
 

--- a/apps/backend/legal-pipeline/src/export/dataset_builder.py
+++ b/apps/backend/legal-pipeline/src/export/dataset_builder.py
@@ -636,6 +636,20 @@ def _normalize_law_meta(parsed_law: dict[str, Any]) -> tuple[str | None, str]:
     return kind_name, classified_level
 
 
+_DELETED_ARTICLE_RE = re.compile(r"제\d[\d의]*조\s+삭제\s*<", re.UNICODE)
+
+
+def _is_header_only_supplementary(text: str) -> bool:
+    lines = [l.strip() for l in text.split("\n") if l.strip()]
+    content = [
+        l for l in lines
+        if not l.startswith("법령명:")
+        and l not in {"구성요소: 부칙", "부칙제목: 부칙"}
+        and not l.startswith("부칙제목:")
+    ]
+    return len(content) == 0
+
+
 def _ensure_unique_record_id(
     record_id: str,
     seen_ids: dict[str, int],
@@ -692,6 +706,8 @@ def build_law_records(
                     text_variant=text_variant,
                     preserve_structure=preserve_structure,
                 )
+                if _DELETED_ARTICLE_RE.search(article_text) and len(article_text) < 150:
+                    continue
                 chunks = _chunk_text(
                     article_text,
                     max_chars=max_chars,
@@ -764,6 +780,8 @@ def build_law_records(
                     text_variant=text_variant,
                     preserve_structure=preserve_structure,
                 )
+                if _is_header_only_supplementary(text):
+                    continue
                 chunks = _chunk_text(
                     text,
                     max_chars=max_chars,

--- a/apps/backend/legal-pipeline/src/parser/law_parser.py
+++ b/apps/backend/legal-pipeline/src/parser/law_parser.py
@@ -786,7 +786,7 @@ def parse_law_body(
         or _first_non_empty(law_root, "법령일련번호", "mst"),
         "ef_yd": (law_ref or {}).get("ef_yd")
         or _first_non_empty(law_root, "시행일자", "ef_yd")
-        or _first_non_empty(law_root.get("기본정보") or {}, "시행일자"),
+        or _first_non_empty(law_root["기본정보"] if isinstance(law_root.get("기본정보"), dict) else {}, "시행일자"),
         "kind_name": (law_ref or {}).get("kind_name")
         or _first_non_empty(law_root, "법령구분명", "법종구분명", "kind_name"),
         "classified_level": (law_ref or {}).get("classified_level"),

--- a/apps/backend/legal-pipeline/src/parser/law_parser.py
+++ b/apps/backend/legal-pipeline/src/parser/law_parser.py
@@ -785,7 +785,8 @@ def parse_law_body(
         "mst": (law_ref or {}).get("mst")
         or _first_non_empty(law_root, "법령일련번호", "mst"),
         "ef_yd": (law_ref or {}).get("ef_yd")
-        or _first_non_empty(law_root, "시행일자", "ef_yd"),
+        or _first_non_empty(law_root, "시행일자", "ef_yd")
+        or _first_non_empty(law_root.get("기본정보") or {}, "시행일자"),
         "kind_name": (law_ref or {}).get("kind_name")
         or _first_non_empty(law_root, "법령구분명", "법종구분명", "kind_name"),
         "classified_level": (law_ref or {}).get("classified_level"),

--- a/apps/backend/legal-pipeline/src/parser/law_parser.py
+++ b/apps/backend/legal-pipeline/src/parser/law_parser.py
@@ -60,11 +60,31 @@ def _as_list(value: Any) -> list[Any]:
     return []
 
 
+_IMG_TAG_RE = re.compile(r"<img[^>]*/?>", re.IGNORECASE)
+
+
+def _flatten_nested_list(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        parts = []
+        for item in value:
+            flat = _flatten_nested_list(item)
+            if flat:
+                parts.append(flat)
+        return "\n".join(parts)
+    return str(value) if value else ""
+
+
 def _normalize_text_preserve_structure(value: Any) -> str | None:
     if value in (None, ""):
         return None
 
+    if isinstance(value, list):
+        value = _flatten_nested_list(value)
+
     text = str(value).replace("\r\n", "\n").replace("\r", "\n").strip()
+    text = _IMG_TAG_RE.sub("", text).strip()
     if not text:
         return None
 


### PR DESCRIPTION
## Work Description
- 부칙 [['']] : 파싱버그수정
  - list 타입을 str() 변환하여 Python reper 문자열이 저장됨
- 이미지 테그 : 제거  
- 삭제 조문 필터링 
  - 반환된 법령 내용 :  "2조 : 삭제됨 <2007.01.03>"값 존재 
- 빈 부칙 : 제거 
  - 법령명/구성요소/부칙제목 외에 법령 정보가 없는 경우 발생
 - ef_yd 누락 : 보완
   - 시행일자가 누락 된 경우가 일부 존재    
 
## Changes
### 변경파일
- apps/backend/legal-pipeline/src/parser/law_parser.py
- apps/backend/legal-pipeline/src/export/dataset_builder.py

### 변경전/후
| 항목 | 변경 전 | 변경 후 |
  |---|---|---|
  | 총 레코드 | 1,982건 | 1,912건 |
  | `[['...']]` 포맷 | 630건 | 0건 |
  | `<img>` 태그 | 11건 | 0건 |
  | 삭제 조문 (전체) | 53건 | 0건 |
  | 빈 껍데기 부칙 | 29건 | 0건 |
  | ef_yd 누락 | 17건 | 0건 |
## Testing
- [x] pyteset 통과 
- [x] 에상 변경 전/후 적용 

## Related Issue
close #176 
