### PR TITLE
[Refactor] legal_case 검증 후 수정

### DIFF
--- a/apps/backend/legal-pipeline/src/collector/legal_doc_collector.py
+++ b/apps/backend/legal-pipeline/src/collector/legal_doc_collector.py
@@ -509,6 +509,7 @@ def collect_list_refs_for_law_name(
     refs: list[dict[str, Any]] = []
     seen: set[tuple[str, str, str]] = set()
     filtered_out = 0
+    expc_keyword_filtered = 0
     exclude_doc_kinds = exclude_doc_kinds or set()
     page = 0
     items: list[dict[str, Any]] = []
@@ -540,6 +541,7 @@ def collect_list_refs_for_law_name(
 
             if target == "expc" and not _is_relevant_expc_item(item, law_name):
                 filtered_out += 1
+                expc_keyword_filtered += 1
                 continue
 
             ref = build_doc_ref(target, law_name, item)
@@ -567,6 +569,13 @@ def collect_list_refs_for_law_name(
             law_name,
             target,
             len(items),
+        )
+
+    if expc_keyword_filtered:
+        logger.info(
+            "collect_list_refs_for_law_name: expc keyword filter dropped=%d law=%s",
+            expc_keyword_filtered,
+            law_name,
         )
 
     return refs, filtered_out

--- a/apps/backend/legal-pipeline/src/collector/legal_doc_collector.py
+++ b/apps/backend/legal-pipeline/src/collector/legal_doc_collector.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from pathlib import Path
 from typing import Any
 
@@ -362,6 +363,34 @@ def should_exclude_doc_item(item: dict[str, Any], exclude_doc_kinds: set[str]) -
     return any(kind in doc_kind for kind in exclude_doc_kinds)
 
 
+_EXPC_SUFFIX_RE = re.compile(r"\s+시행(?:령|규칙|규정)?$|\s+규칙$")
+
+
+def _extract_expc_keyword(law_name: str) -> str:
+    """법령명에서 expc 사전 필터용 핵심 키워드를 추출한다.
+
+    시행령/시행규칙 접미사를 제거한 뒤 첫 어절을 반환한다.
+    예: "근로기준법 시행령" → "근로기준법"
+        "남녀고용평등과 일·가정 양립 지원에 관한 법률" → "남녀고용평등과"
+    """
+    base = _EXPC_SUFFIX_RE.sub("", law_name).strip()
+    tokens = (base or law_name).split()
+    return tokens[0] if tokens else law_name
+
+
+def _is_relevant_expc_item(item: dict[str, Any], law_name: str) -> bool:
+    """expc 목록 항목의 안건명에 law_name 핵심 키워드가 포함되는지 확인한다.
+
+    API search=2 쿼리는 넓은 범위를 반환하므로, 안건명 기반 사전 필터로
+    후속 다운로드·정제 비용을 줄인다.
+    """
+    title = str(item.get("안건명") or "").strip()
+    if not title:
+        return True  # 제목 없는 항목은 통과시켜 하위 단계에서 처리
+    keyword = _extract_expc_keyword(law_name)
+    return keyword in title
+
+
 
 def build_doc_ref(
     target: str,
@@ -506,6 +535,10 @@ def collect_list_refs_for_law_name(
 
         for item in items:
             if should_exclude_doc_item(item, exclude_doc_kinds):
+                filtered_out += 1
+                continue
+
+            if target == "expc" and not _is_relevant_expc_item(item, law_name):
                 filtered_out += 1
                 continue
 

--- a/apps/backend/legal-pipeline/src/common/io_utils.py
+++ b/apps/backend/legal-pipeline/src/common/io_utils.py
@@ -8,6 +8,7 @@ from typing import Any, Iterable, Iterator
 
 def _safe_filename(text: str) -> str:
     text = text.strip()
+    text = text.replace("ㆍ", "·")  # U+318D (Korean interpunct) → U+00B7 (middle dot), both → _
     text = re.sub(r"[^\w가-힣.-]+", "_", text)
     text = re.sub(r"_+", "_", text)
     return text.strip("_") or "unnamed"

--- a/apps/backend/legal-pipeline/src/common/law_meta.py
+++ b/apps/backend/legal-pipeline/src/common/law_meta.py
@@ -80,6 +80,8 @@ def normalize_identifier_token(value: Any) -> str:
         return "unknown"
 
     text = text.replace("::", "-")
+    # U+318D (Korean interpunct ㆍ) → U+00B7 (middle dot ·) 통일
+    text = text.replace("ㆍ", "·")
     text = re.sub(r"\s+", "_", text)
     text = re.sub(r"[\\/]+", "-", text)
     return text

--- a/apps/backend/legal-pipeline/src/export/dataset_builder.py
+++ b/apps/backend/legal-pipeline/src/export/dataset_builder.py
@@ -1209,10 +1209,15 @@ def build_relation_records(
 
 def build_case_reference_audit_records(
     raw_related_base_dir: str | Path = "data/raw/02_related_legal_docs",
+    *,
+    include_body_regex: bool = True,
 ) -> list[dict[str, Any]]:
     from src.export.legal_case_relation_builder import build_case_reference_audit_records as _build_case_reference_audit_records
 
-    return _build_case_reference_audit_records(raw_related_base_dir=raw_related_base_dir)
+    return _build_case_reference_audit_records(
+        raw_related_base_dir=raw_related_base_dir,
+        include_body_regex=include_body_regex,
+    )
 
 
 def build_and_write_datasets(
@@ -1232,6 +1237,7 @@ def build_and_write_datasets(
     include_appendix_bundle_text_in_payload: bool = True,
     write_legacy_appendix_datasets: bool = True,
     include_law_to_law_relations: bool = True,
+    audit_include_body_regex: bool = True,
 ) -> dict[str, Any]:
     output_dir = Path(output_dir)
 
@@ -1260,6 +1266,7 @@ def build_and_write_datasets(
     )
     case_reference_audit_records = build_case_reference_audit_records(
         raw_related_base_dir=raw_related_base_dir,
+        include_body_regex=audit_include_body_regex,
     )
 
     appendix_manifest: dict[str, Any] | None = None

--- a/apps/backend/legal-pipeline/src/export/law_to_law_relation_builder.py
+++ b/apps/backend/legal-pipeline/src/export/law_to_law_relation_builder.py
@@ -9,6 +9,7 @@ Observed relation examples from the current dataset:
 
 from __future__ import annotations
 
+import re
 from collections import defaultdict
 from pathlib import Path
 from typing import Any
@@ -20,6 +21,24 @@ from src.parser.legal_case_parser import (
     find_related_law_names,
 )
 from src.parser.law_reference_parser import parse_law_article_references
+
+
+_RELATIVE_LAW_WORDS = frozenset(["동법", "동조", "법", "령"])
+
+
+def _is_valid_law_name(name: str) -> bool:
+    """의미 없는 법령명 파편을 걸러낸다 (파서 노이즈)."""
+    stripped = name.strip()
+    if not stripped:
+        return False
+    # "동법", "동조" 등 지시 상대 참조 단어
+    if stripped in _RELATIVE_LAW_WORDS:
+        return False
+    # " 법"으로 끝나는 파편 (조사/접속사 + 법): "따라 법", "경우 법", "이란 법" 등
+    # 단, "에 관한" / "관련" 이 포함된 정식 법률명은 허용
+    if stripped.endswith(" 법") and "에 관한" not in stripped and "관련" not in stripped:
+        return False
+    return True
 
 
 def _normalize_space(text: str) -> str:
@@ -163,9 +182,17 @@ def build_law_to_law_relation_records(
         family_law_names = [row["law_name"] for row in laws]
         uid_by_name = {row["law_name"]: row["law_uid"] for row in laws}
         law_meta_by_name = {row["law_name"]: row for row in laws}
-        root_law_uid = uid_by_name.get(root_law_name) or build_strict_law_uid(
-            law_meta_by_name.get(root_law_name, {}).get("law_id"),
-            law_meta_by_name.get(root_law_name, {}).get("mst"),
+        # Normalized lookup: directory restoration loses ·/ㆍ → match by stripping spaces and dots
+        _norm = lambda n: n.replace("ㆍ", "").replace("·", "").replace(" ", "")
+        uid_by_normalized = {_norm(row["law_name"]): row["law_uid"] for row in laws}
+        meta_by_normalized = {_norm(row["law_name"]): row for row in laws}
+        root_law_uid = (
+            uid_by_name.get(root_law_name)
+            or uid_by_normalized.get(_norm(root_law_name))
+            or build_strict_law_uid(
+                (meta_by_normalized.get(_norm(root_law_name)) or {}).get("law_id"),
+                (meta_by_normalized.get(_norm(root_law_name)) or {}).get("mst"),
+            )
         )
         family_alias_map = _family_laws_by_alias(root_law_name, laws)
 
@@ -246,6 +273,8 @@ def build_law_to_law_relation_records(
                         )
 
                 for target_law_name, target_refs in sorted(refs_by_target.items()):
+                    if not _is_valid_law_name(target_law_name):
+                        continue
                     target_meta = law_meta_by_name.get(target_law_name)
                     target_law_uid = uid_by_name.get(target_law_name) if target_meta else None
                     target_article_refs = article_refs_map.get(target_law_name, [])

--- a/apps/backend/legal-pipeline/src/export/legal_case_relation_builder.py
+++ b/apps/backend/legal-pipeline/src/export/legal_case_relation_builder.py
@@ -324,29 +324,7 @@ def build_case_to_case_relation_records(
     if any(expc_mapping_stats.values()):
         _log.info("expc->prec mapping stats: %s", expc_mapping_stats)
 
-    rows = [records_by_id[key] for key in sorted(records_by_id)]
-    return _dedup_bidirectional_c2c(rows)
-
-
-def _dedup_bidirectional_c2c(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """case_to_case 양방향 중복(A→B, B→A)을 제거하고 한 방향만 유지한다.
-
-    정렬된 (min_cid, max_cid) 쌍 기준으로 먼저 등장한 레코드를 보존한다.
-    """
-    seen_pairs: set[tuple[str, str]] = set()
-    deduped: list[dict[str, Any]] = []
-    for row in rows:
-        src = str(row.get("source_canonical_case_id") or "").strip()
-        tgt = str(row.get("target_canonical_case_id") or "").strip()
-        if not src or not tgt:
-            deduped.append(row)
-            continue
-        canonical_pair = (min(src, tgt), max(src, tgt))
-        if canonical_pair in seen_pairs:
-            continue
-        seen_pairs.add(canonical_pair)
-        deduped.append(row)
-    return deduped
+    return [records_by_id[key] for key in sorted(records_by_id)]
 
 
 def build_case_reference_audit_records(

--- a/apps/backend/legal-pipeline/src/export/legal_case_relation_builder.py
+++ b/apps/backend/legal-pipeline/src/export/legal_case_relation_builder.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import json
+import logging
 import re
 from collections import defaultdict
 from pathlib import Path
 from typing import Any
+
+_log = logging.getLogger(__name__)
 
 from src.common.io_utils import _safe_filename
 from src.export.legal_case_dataset_builder import (
@@ -140,6 +144,7 @@ def build_case_to_case_relation_records(
             doc_id_index[did].append(cr)
 
     records_by_id: dict[str, dict[str, Any]] = {}
+    expc_mapping_stats: dict[str, int] = {"success": 0, "no_candidate": 0, "ambiguous": 0}
 
     for row in canonical_rows:
         source_canonical_case_id = str(
@@ -162,8 +167,13 @@ def build_case_to_case_relation_records(
                     and str(c.get("canonical_case_id") or c.get("canonical_id") or c.get("id") or "").strip()
                     != source_canonical_case_id
                 ]
-                if len(candidates) != 1:
+                if len(candidates) == 0:
+                    expc_mapping_stats["no_candidate"] += 1
                     continue
+                if len(candidates) > 1:
+                    expc_mapping_stats["ambiguous"] += 1
+                    continue
+                expc_mapping_stats["success"] += 1
                 target_row = candidates[0]
                 target_cid = str(
                     target_row.get("canonical_case_id") or target_row.get("canonical_id") or target_row.get("id") or ""
@@ -307,6 +317,9 @@ def build_case_to_case_relation_records(
             record["embedding_text"] = _build_case_to_case_text(record)
             record["text"] = record["embedding_text"]
             records_by_id[relation_id] = record
+
+    if any(expc_mapping_stats.values()):
+        _log.info("expc->prec mapping stats: %s", expc_mapping_stats)
 
     return [records_by_id[key] for key in sorted(records_by_id)]
 

--- a/apps/backend/legal-pipeline/src/export/legal_case_relation_builder.py
+++ b/apps/backend/legal-pipeline/src/export/legal_case_relation_builder.py
@@ -313,7 +313,15 @@ def build_case_to_case_relation_records(
 
 def build_case_reference_audit_records(
     raw_related_base_dir: str | Path = "data/raw/02_related_legal_docs",
+    *,
+    include_body_regex: bool = True,
 ) -> list[dict[str, Any]]:
+    """audit 레코드를 생성한다.
+
+    include_body_regex=True (기본): body_text 정규식 검색 포함 — 최대 커버리지
+    include_body_regex=False: structured_field만 사용 — export graph(use_body_regex_fallback=False)와
+                              동일 기준으로 비교할 때 사용
+    """
     canonical_rows, doc_number_index, _ = _iter_case_reference_candidates(raw_related_base_dir)
     if not canonical_rows:
         return []
@@ -336,7 +344,11 @@ def build_case_reference_audit_records(
         source_doc_number = parsed.get("doc_number") or row.get("doc_number")
         body_text = str(parsed.get("body_text") or "").strip()
 
-        referenced_case_rows = _merge_referenced_case_numbers(parsed, body_text, source_doc_number)
+        referenced_case_rows = _merge_referenced_case_numbers(
+            parsed,
+            body_text if include_body_regex else "",
+            source_doc_number,
+        )
         for ref_row in referenced_case_rows:
             referenced_case_number = str(ref_row.get("case_number") or "").strip()
             normalized_ref = _normalize_case_number(referenced_case_number)
@@ -371,6 +383,7 @@ def build_case_reference_audit_records(
                 {
                     "id": f"case_ref_audit::{source_canonical_case_id}::{normalized_ref}",
                     "audit_type": "case_reference_resolution",
+                    "audit_includes_body_regex": include_body_regex,
                     "source_canonical_case_id": source_canonical_case_id,
                     "source_target": source_target,
                     "source_title": parsed.get("title"),

--- a/apps/backend/legal-pipeline/src/export/legal_case_relation_builder.py
+++ b/apps/backend/legal-pipeline/src/export/legal_case_relation_builder.py
@@ -10,6 +10,7 @@ from typing import Any
 _log = logging.getLogger(__name__)
 
 from src.common.io_utils import _safe_filename
+from src.common.law_meta import build_law_uid
 from src.export.legal_case_dataset_builder import (
     _iter_canonical_case_rows,
     _load_detail_payload,
@@ -213,6 +214,7 @@ def build_case_to_case_relation_records(
                     "referenced_case_number": target_row.get("doc_number"),
                     "reference_sources": ["html_scraping"],
                     "root_law_name": row.get("root_law_name"),
+                    "root_law_uid": build_law_uid(None, None, row.get("root_law_name")) if row.get("root_law_name") else None,
                     "root_law_names": row.get("root_law_names") or [],
                     "related_law_names": row.get("source_law_names") or [],
                     "source_law_name": (row.get("source_law_names") or [None])[0],
@@ -303,6 +305,7 @@ def build_case_to_case_relation_records(
                 "referenced_case_number": referenced_case_number,
                 "reference_sources": list(ref_row.get("reference_sources") or []),
                 "root_law_name": row.get("root_law_name"),
+                "root_law_uid": build_law_uid(None, None, row.get("root_law_name")) if row.get("root_law_name") else None,
                 "root_law_names": row.get("root_law_names") or [],
                 "related_law_names": row.get("source_law_names") or [],
                 "source_law_name": (row.get("source_law_names") or [None])[0],
@@ -321,7 +324,29 @@ def build_case_to_case_relation_records(
     if any(expc_mapping_stats.values()):
         _log.info("expc->prec mapping stats: %s", expc_mapping_stats)
 
-    return [records_by_id[key] for key in sorted(records_by_id)]
+    rows = [records_by_id[key] for key in sorted(records_by_id)]
+    return _dedup_bidirectional_c2c(rows)
+
+
+def _dedup_bidirectional_c2c(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """case_to_case 양방향 중복(A→B, B→A)을 제거하고 한 방향만 유지한다.
+
+    정렬된 (min_cid, max_cid) 쌍 기준으로 먼저 등장한 레코드를 보존한다.
+    """
+    seen_pairs: set[tuple[str, str]] = set()
+    deduped: list[dict[str, Any]] = []
+    for row in rows:
+        src = str(row.get("source_canonical_case_id") or "").strip()
+        tgt = str(row.get("target_canonical_case_id") or "").strip()
+        if not src or not tgt:
+            deduped.append(row)
+            continue
+        canonical_pair = (min(src, tgt), max(src, tgt))
+        if canonical_pair in seen_pairs:
+            continue
+        seen_pairs.add(canonical_pair)
+        deduped.append(row)
+    return deduped
 
 
 def build_case_reference_audit_records(

--- a/apps/backend/legal-pipeline/src/export/legal_relation_builder.py
+++ b/apps/backend/legal-pipeline/src/export/legal_relation_builder.py
@@ -539,8 +539,19 @@ def build_legal_relation_records(
                 )
 
             result = _dedup_family_search_hits(_merge_relation_rows(built_rows))
-            return [r for r in result if not _is_unverified_search_hit(r)]
+            filtered = [r for r in result if not _is_unverified_search_hit(r)]
+            dropped = len(result) - len(filtered)
+            if dropped:
+                logger.warning(
+                    "build_legal_relation_records: unverified_search_hit dropped=%d path=raw",
+                    dropped,
+                )
+            return filtered
 
+    if raw_related_base_dir is not None:
+        logger.warning(
+            "build_legal_relation_records: raw path had no data, using expanded fallback"
+        )
     expanded_dir = Path(expanded_base_dir)
     if raw_related_base_dir is not None and expanded_dir == Path("data/expanded/03_expanded_related_docs"):
         raw_dir = Path(raw_related_base_dir)
@@ -551,7 +562,14 @@ def build_legal_relation_records(
         rows.extend(list(_iter_jsonl(path)))
     if rows:
         result = _merge_relation_rows(rows)
-        return [r for r in result if not _is_unverified_search_hit(r)]
+        filtered = [r for r in result if not _is_unverified_search_hit(r)]
+        dropped = len(result) - len(filtered)
+        if dropped:
+            logger.warning(
+                "build_legal_relation_records: unverified_search_hit dropped=%d path=fallback",
+                dropped,
+            )
+        return filtered
 
     return []
 

--- a/apps/backend/legal-pipeline/tests/test_io_utils.py
+++ b/apps/backend/legal-pipeline/tests/test_io_utils.py
@@ -1,0 +1,26 @@
+"""io_utils 단위 테스트 — _safe_filename 중점 정규화 (이슈 H)."""
+
+from src.common.io_utils import _safe_filename
+
+
+class TestSafeFilename:
+    def test_middle_dot_u00b7_becomes_underscore(self):
+        assert _safe_filename("남녀고용평등과 일·가정") == "남녀고용평등과_일_가정"
+
+    def test_korean_interpunct_u318d_also_becomes_underscore(self):
+        # U+318D (ㆍ) 이전에는 \w 매치로 보존됐음 — 정규화 후 동일 결과
+        assert _safe_filename("남녀고용평등과 일ㆍ가정") == "남녀고용평등과_일_가정"
+
+    def test_both_variants_produce_same_result(self):
+        a = _safe_filename("남녀고용평등과 일·가정 양립 지원에 관한 법률")
+        b = _safe_filename("남녀고용평등과 일ㆍ가정 양립 지원에 관한 법률")
+        assert a == b, "· 와 ㆍ 가 다른 파일명을 생성해 경로 분기 발생"
+
+    def test_space_only_variant_same_as_dot_variants(self):
+        a = _safe_filename("남녀고용평등과 일 가정 양립 지원에 관한 법률")
+        b = _safe_filename("남녀고용평등과 일·가정 양립 지원에 관한 법률")
+        assert a == b
+
+    def test_normal_law_names_unchanged(self):
+        assert _safe_filename("근로기준법") == "근로기준법"
+        assert _safe_filename("건설산업기본법 시행령") == "건설산업기본법_시행령"

--- a/apps/backend/legal-pipeline/tests/test_law_meta.py
+++ b/apps/backend/legal-pipeline/tests/test_law_meta.py
@@ -1,0 +1,36 @@
+"""tests for src/common/law_meta.py"""
+
+import pytest
+from src.common.law_meta import build_law_uid, normalize_identifier_token
+
+
+class TestNormalizeIdentifierToken:
+    def test_middle_dot_variants_produce_same_token(self):
+        # U+00B7 (·) vs U+318D (ㆍ) must yield identical output
+        a = normalize_identifier_token("남녀고용평등과 일·가정 양립 지원에 관한 법률")
+        b = normalize_identifier_token("남녀고용평등과 일ㆍ가정 양립 지원에 관한 법률")
+        assert a == b
+
+    def test_spaces_replaced_with_underscore(self):
+        assert normalize_identifier_token("법률 이름") == "법률_이름"
+
+    def test_double_colon_replaced_with_dash(self):
+        assert normalize_identifier_token("a::b") == "a-b"
+
+    def test_empty_returns_unknown(self):
+        assert normalize_identifier_token("") == "unknown"
+        assert normalize_identifier_token(None) == "unknown"
+
+
+class TestBuildLawUid:
+    def test_middle_dot_variants_produce_same_uid(self):
+        uid_a = build_law_uid(None, None, "남녀고용평등과 일·가정 양립 지원에 관한 법률")
+        uid_b = build_law_uid(None, None, "남녀고용평등과 일ㆍ가정 양립 지원에 관한 법률")
+        assert uid_a == uid_b
+
+    def test_law_id_takes_priority_over_law_name(self):
+        uid = build_law_uid("123456", None, "어떤 법률")
+        assert uid == "123456"
+
+    def test_all_none_returns_unknown_law(self):
+        assert build_law_uid(None, None, None) == "unknown-law"

--- a/apps/backend/legal-pipeline/tests/test_law_to_law_relation_builder.py
+++ b/apps/backend/legal-pipeline/tests/test_law_to_law_relation_builder.py
@@ -1,5 +1,8 @@
 from src.common.io_utils import _write_json
-from src.export.law_to_law_relation_builder import build_law_to_law_relation_records
+from src.export.law_to_law_relation_builder import (
+    _is_valid_law_name,
+    build_law_to_law_relation_records,
+)
 
 
 def test_build_law_to_law_relation_records_extracts_explicit_law_and_article_refs(tmp_path):
@@ -166,3 +169,100 @@ def test_build_law_to_law_relation_records_recovers_noisy_scope_reference_as_fam
     assert row["article_keys"] == ["48"]
     assert row["resolution_status"] == "resolved"
     assert "relative_reference" in row["relation_types"]
+
+
+class TestIsValidLawName:
+    """이슈 K: 의미 없는 법령명 파편 필터."""
+
+    def test_rejects_single_char_variants(self):
+        assert _is_valid_law_name("동법") is False
+
+    def test_rejects_particle_fragment_ending_with_space_법(self):
+        assert _is_valid_law_name("따라 법") is False
+        assert _is_valid_law_name("경우 법") is False
+        assert _is_valid_law_name("이란 법") is False
+        assert _is_valid_law_name("란 법") is False
+        assert _is_valid_law_name("투자설명서상 법") is False
+        assert _is_valid_law_name("하수급인에게 법") is False
+
+    def test_allows_real_law_names(self):
+        assert _is_valid_law_name("근로기준법") is True
+        assert _is_valid_law_name("민법") is True  # 2글자지만 실제 법령명
+        assert _is_valid_law_name("체육시설의 설치·이용에 관한 법률") is True
+        assert _is_valid_law_name("근로자퇴직급여 보장법") is True
+
+    def test_allows_에관한_ending_law(self):
+        assert _is_valid_law_name("건강 및 안전에 관한 법") is True
+
+
+def test_build_law_to_law_records_root_law_uid_with_middle_dot_directory(tmp_path):
+    """이슈 J: 디렉토리명 복원 시 중점 소실로 root_law_uid가 null이 되는 버그 수정."""
+    # 디렉토리명은 _safe_filename 으로 생성 → ·(U+00B7) → _
+    normalized_dir = (
+        tmp_path / "normalized" / "01_current_law"
+        / "남녀고용평등과_일_가정_양립_지원에_관한_법률"
+    )
+
+    # 페이로드의 law_name은 ·(또는 ㆍ) 포함
+    _write_json(
+        normalized_dir / "남녀고용평등과_일_가정_양립_지원에_관한_법률__parsed_law.json",
+        {
+            "law_name": "남녀고용평등과 일·가정 양립 지원에 관한 법률",
+            "law_id": "003881",
+            "mst": "271000",
+            "ef_yd": "20250101",
+            "kind_name": "법률",
+            "classified_level": "법",
+            "articles": [
+                {
+                    "article_key": "19",
+                    "article_no": "제19조",
+                    "article_no_display": "제19조",
+                    "article_title": "육아휴직",
+                    # 법령명 명시 참조 → same_law_reference row 생성
+                    "article_text_raw": "남녀고용평등과 일·가정 양립 지원에 관한 법률 제20조에 따른 육아휴직을 보장한다.",
+                }
+            ],
+        },
+    )
+
+    rows = build_law_to_law_relation_records(tmp_path / "normalized" / "01_current_law")
+
+    # same_law_reference 행이 생성되며 root_law_uid가 null이 아니어야 한다
+    assert len(rows) >= 1
+    assert all(row["root_law_uid"] is not None for row in rows), \
+        "root_law_uid null: 디렉토리명 복원 시 중점 소실 버그"
+
+
+def test_build_law_to_law_records_filters_noisy_external_law_names(tmp_path):
+    """이슈 K: 파서가 추출한 의미 없는 법령명 파편이 law_to_law에 포함되지 않아야 한다."""
+    normalized_dir = (
+        tmp_path / "normalized" / "01_current_law" / "근로기준법"
+    )
+
+    _write_json(
+        normalized_dir / "근로기준법__parsed_law.json",
+        {
+            "law_name": "근로기준법",
+            "law_id": "001872",
+            "mst": "269390",
+            "ef_yd": "20250101",
+            "kind_name": "법률",
+            "classified_level": "법",
+            "articles": [
+                {
+                    "article_key": "1",
+                    "article_no": "제1조",
+                    "article_no_display": "제1조",
+                    "article_title": "목적",
+                    # "따라 법 제3조" 형태의 파편이 포함된 텍스트
+                    "article_text_raw": "이 법은 민법 제750조 및 따라 법 제3조에 따른다.",
+                }
+            ],
+        },
+    )
+
+    rows = build_law_to_law_relation_records(tmp_path / "normalized" / "01_current_law")
+
+    law_names = {row["law_name"] for row in rows}
+    assert "따라 법" not in law_names, '"따라 법" 파편이 법령 관계에 포함됨'

--- a/apps/backend/legal-pipeline/tests/test_legal_case_relation_builder.py
+++ b/apps/backend/legal-pipeline/tests/test_legal_case_relation_builder.py
@@ -239,6 +239,72 @@ def test_build_case_reference_audit_records_tracks_ambiguous_and_unresolved(tmp_
     assert by_ref["2018다12345"]["reference_sources"] == ["body_regex"]
     assert by_ref["2027다99999"]["resolution_status"] == "unresolved_external"
     assert by_ref["2027다99999"]["candidate_count"] == 0
+    # 기본값(True)이면 모든 row에 audit_includes_body_regex=True 기록
+    assert all(r["audit_includes_body_regex"] is True for r in records)
+
+
+def test_build_case_reference_audit_records_structured_only(tmp_path):
+    """include_body_regex=False: body_text 기반 참조는 제외, export graph와 동일 기준."""
+    raw_dir = tmp_path / "raw" / "02_related_legal_docs"
+    root = raw_dir / "근로기준법"
+
+    source_detail_path = root / "canonical" / "prec" / "case_prec_123456__detail.json"
+    _write_json(
+        source_detail_path,
+        {
+            "판례일련번호": "123456",
+            "사건명": "임금",
+            "사건번호": "2019다12345",
+            "선고일자": "2019.05.30",
+            # 구조화 참조 없음 — body text에만 사건번호 존재
+            "판례내용": "이 사건은 2018다12345 판결을 참조하였다.",
+        },
+    )
+    _write_jsonl(
+        root / "canonical_cases.jsonl",
+        [
+            {
+                "id": "case::prec::123456",
+                "canonical_case_id": "case::prec::123456",
+                "canonical_id": "case::prec::123456",
+                "target": "prec",
+                "doc_id": "123456",
+                "doc_number": "2019다12345",
+                "root_law_name": "근로기준법",
+                "source_law_names": ["근로기준법"],
+                "source_law_uids": ["law-001"],
+                "detail_available": True,
+                "detail_payload_path": str(source_detail_path),
+            },
+            {
+                "id": "case::prec::777777",
+                "canonical_case_id": "case::prec::777777",
+                "canonical_id": "case::prec::777777",
+                "target": "prec",
+                "doc_id": "777777",
+                "doc_number": "2018다12345",
+                "root_law_name": "근로기준법",
+                "source_law_names": ["근로기준법"],
+                "source_law_uids": ["law-001"],
+                "detail_available": False,
+                "detail_payload_path": None,
+            },
+        ],
+    )
+
+    # structured_only: body_regex 참조 제외 → 결과 0건
+    records_structured = build_case_reference_audit_records(
+        raw_related_base_dir=raw_dir, include_body_regex=False
+    )
+    assert records_structured == []
+
+    # body_regex 포함(기본): 결과 1건
+    records_full = build_case_reference_audit_records(
+        raw_related_base_dir=raw_dir, include_body_regex=True
+    )
+    assert len(records_full) == 1
+    assert records_full[0]["reference_sources"] == ["body_regex"]
+    assert records_full[0]["audit_includes_body_regex"] is True
 
 
 def test_build_case_to_case_relation_records_uses_structured_reference_field(tmp_path):

--- a/apps/backend/legal-pipeline/tests/test_legal_case_relation_builder.py
+++ b/apps/backend/legal-pipeline/tests/test_legal_case_relation_builder.py
@@ -507,12 +507,11 @@ def test_build_case_to_case_relation_records_sets_root_law_uid(tmp_path):
     assert "근로기준법" in record["root_law_uid"]
 
 
-def test_build_case_to_case_relation_records_deduplicates_bidirectional(tmp_path):
-    """이슈 N: A→B와 B→A가 동시에 생성될 때 하나만 유지된다."""
+def test_build_case_to_case_relation_records_preserves_bidirectional_edges(tmp_path):
+    """상호 인용(A→B, B→A)은 각각 독립된 사실이므로 두 엣지 모두 보존된다."""
     raw_dir = tmp_path / "raw" / "02_related_legal_docs"
     root = raw_dir / "근로기준법"
 
-    # source A references B via structured field
     detail_a = root / "canonical" / "prec" / "case_prec_AAA__detail.json"
     _write_json(
         detail_a,
@@ -523,7 +522,6 @@ def test_build_case_to_case_relation_records_deduplicates_bidirectional(tmp_path
             "판례내용": "선행 2018다222 판결 참조.",
         },
     )
-    # source B references A via structured field (creates reverse edge)
     detail_b = root / "canonical" / "prec" / "case_prec_BBB__detail.json"
     _write_json(
         detail_b,
@@ -556,7 +554,7 @@ def test_build_case_to_case_relation_records_deduplicates_bidirectional(tmp_path
                 "canonical_id": "case::prec::BBB",
                 "target": "prec",
                 "doc_id": "BBB",
-                "doc_number": "2018da222",
+                "doc_number": "2018다222",
                 "root_law_name": "근로기준법",
                 "source_law_names": ["근로기준법"],
                 "detail_available": True,
@@ -567,11 +565,10 @@ def test_build_case_to_case_relation_records_deduplicates_bidirectional(tmp_path
 
     records = build_case_to_case_relation_records(raw_related_base_dir=raw_dir)
 
-    # 양방향이 생성됐더라도 최종 결과는 1건이어야 함
     pairs = {
         (r["source_canonical_case_id"], r["target_canonical_case_id"])
         for r in records
     }
-    # 정방향, 역방향이 동시에 존재해서는 안 됨
-    for src, tgt in list(pairs):
-        assert (tgt, src) not in pairs, "양방향 중복 레코드가 dedup 없이 포함됨"
+    # 상호 인용이므로 정방향·역방향 엣지가 모두 존재해야 함
+    assert ("case::prec::AAA", "case::prec::BBB") in pairs, "A→B 엣지 누락"
+    assert ("case::prec::BBB", "case::prec::AAA") in pairs, "B→A 엣지 누락 (상호 인용은 별개 사실)"

--- a/apps/backend/legal-pipeline/tests/test_legal_case_relation_builder.py
+++ b/apps/backend/legal-pipeline/tests/test_legal_case_relation_builder.py
@@ -442,3 +442,136 @@ def test_build_case_to_case_relation_records_logs_expc_mapping_stats(tmp_path, c
     assert stat_logs, "mapping stats info 로그가 기록되어야 한다"
     assert "success" in stat_logs[0]
     assert "no_candidate" in stat_logs[0]
+
+
+def test_build_case_to_case_relation_records_sets_root_law_uid(tmp_path):
+    """case_to_case 레코드에 root_law_uid가 null 없이 설정된다 (이슈 F)."""
+    raw_dir = tmp_path / "raw" / "02_related_legal_docs"
+    root = raw_dir / "근로기준법"
+
+    source_detail_path = root / "canonical" / "prec" / "case_prec_123456__detail.json"
+    _write_json(
+        source_detail_path,
+        {
+            "판례일련번호": "123456",
+            "사건번호": "2019다12345",
+            "선고일자": "2019.05.30",
+            "참조판례": "대법원 2018. 4. 20. 선고 2018다12345 판결",
+            "판례내용": "이 사건은 근로기준법 제43조를 적용하여 2018다12345 판결의 법리를 따랐다.",
+        },
+    )
+    target_detail_path = root / "canonical" / "prec" / "case_prec_777777__detail.json"
+    _write_json(
+        target_detail_path,
+        {"판례일련번호": "777777", "사건번호": "2018다12345", "판례내용": "선행 판결"},
+    )
+
+    _write_jsonl(
+        root / "canonical_cases.jsonl",
+        [
+            {
+                "id": "case::prec::123456",
+                "canonical_case_id": "case::prec::123456",
+                "canonical_id": "case::prec::123456",
+                "target": "prec",
+                "doc_id": "123456",
+                "doc_number": "2019다12345",
+                "root_law_name": "근로기준법",
+                "source_law_names": ["근로기준법"],
+                "source_law_uids": ["law-001"],
+                "detail_available": True,
+                "detail_payload_path": str(source_detail_path),
+            },
+            {
+                "id": "case::prec::777777",
+                "canonical_case_id": "case::prec::777777",
+                "canonical_id": "case::prec::777777",
+                "target": "prec",
+                "doc_id": "777777",
+                "doc_number": "2018다12345",
+                "root_law_name": "근로기준법",
+                "source_law_names": ["근로기준법"],
+                "source_law_uids": ["law-001"],
+                "detail_available": True,
+                "detail_payload_path": str(target_detail_path),
+            },
+        ],
+    )
+
+    records = build_case_to_case_relation_records(raw_related_base_dir=raw_dir)
+
+    assert len(records) == 1
+    record = records[0]
+    assert record["root_law_name"] == "근로기준법"
+    assert record["root_law_uid"] is not None, "root_law_uid가 null이면 Neo4j 그래프 edge 누락 발생"
+    assert "근로기준법" in record["root_law_uid"]
+
+
+def test_build_case_to_case_relation_records_deduplicates_bidirectional(tmp_path):
+    """이슈 N: A→B와 B→A가 동시에 생성될 때 하나만 유지된다."""
+    raw_dir = tmp_path / "raw" / "02_related_legal_docs"
+    root = raw_dir / "근로기준법"
+
+    # source A references B via structured field
+    detail_a = root / "canonical" / "prec" / "case_prec_AAA__detail.json"
+    _write_json(
+        detail_a,
+        {
+            "판례일련번호": "AAA",
+            "사건번호": "2019다111",
+            "참조판례": "대법원 2018. 1. 1. 선고 2018다222 판결",
+            "판례내용": "선행 2018다222 판결 참조.",
+        },
+    )
+    # source B references A via structured field (creates reverse edge)
+    detail_b = root / "canonical" / "prec" / "case_prec_BBB__detail.json"
+    _write_json(
+        detail_b,
+        {
+            "판례일련번호": "BBB",
+            "사건번호": "2018다222",
+            "참조판례": "대법원 2019. 5. 1. 선고 2019다111 판결",
+            "판례내용": "후속 2019다111 판결을 인용.",
+        },
+    )
+
+    _write_jsonl(
+        root / "canonical_cases.jsonl",
+        [
+            {
+                "id": "case::prec::AAA",
+                "canonical_case_id": "case::prec::AAA",
+                "canonical_id": "case::prec::AAA",
+                "target": "prec",
+                "doc_id": "AAA",
+                "doc_number": "2019다111",
+                "root_law_name": "근로기준법",
+                "source_law_names": ["근로기준법"],
+                "detail_available": True,
+                "detail_payload_path": str(detail_a),
+            },
+            {
+                "id": "case::prec::BBB",
+                "canonical_case_id": "case::prec::BBB",
+                "canonical_id": "case::prec::BBB",
+                "target": "prec",
+                "doc_id": "BBB",
+                "doc_number": "2018da222",
+                "root_law_name": "근로기준법",
+                "source_law_names": ["근로기준법"],
+                "detail_available": True,
+                "detail_payload_path": str(detail_b),
+            },
+        ],
+    )
+
+    records = build_case_to_case_relation_records(raw_related_base_dir=raw_dir)
+
+    # 양방향이 생성됐더라도 최종 결과는 1건이어야 함
+    pairs = {
+        (r["source_canonical_case_id"], r["target_canonical_case_id"])
+        for r in records
+    }
+    # 정방향, 역방향이 동시에 존재해서는 안 됨
+    for src, tgt in list(pairs):
+        assert (tgt, src) not in pairs, "양방향 중복 레코드가 dedup 없이 포함됨"

--- a/apps/backend/legal-pipeline/tests/test_legal_case_relation_builder.py
+++ b/apps/backend/legal-pipeline/tests/test_legal_case_relation_builder.py
@@ -383,3 +383,62 @@ def test_build_case_to_case_relation_records_uses_structured_reference_field(tmp
     assert len(records) == 1
     assert records[0]["referenced_case_number"] == "2018다12345"
     assert records[0]["reference_sources"] == ["structured_field"]
+
+
+def test_build_case_to_case_relation_records_logs_expc_mapping_stats(tmp_path, caplog):
+    """expc→prec 매핑 결과(success/no_candidate/ambiguous)가 info 로그로 기록된다."""
+    import json
+    import logging
+
+    raw_dir = tmp_path / "raw" / "02_related_legal_docs"
+    root = raw_dir / "근로기준법"
+
+    # expc canonical row
+    expc_cid = "case::expc::9001"
+    _write_jsonl(
+        root / "canonical_cases.jsonl",
+        [
+            {
+                "id": expc_cid,
+                "canonical_case_id": expc_cid,
+                "canonical_id": expc_cid,
+                "target": "expc",
+                "doc_id": "9001",
+                "doc_number": "21-0001",
+                "root_law_name": "근로기준법",
+                "source_law_names": ["근로기준법"],
+                "source_law_uids": ["law-001"],
+                "detail_available": False,
+                "detail_payload_path": None,
+            },
+            {
+                "id": "case::prec::111",
+                "canonical_case_id": "case::prec::111",
+                "canonical_id": "case::prec::111",
+                "target": "prec",
+                "doc_id": "111",
+                "doc_number": "2018다111",
+                "root_law_name": "근로기준법",
+                "source_law_names": ["근로기준법"],
+                "source_law_uids": ["law-001"],
+                "detail_available": False,
+                "detail_payload_path": None,
+            },
+        ],
+    )
+
+    # sidecar: prec_id=111 (success) + prec_id=999 (no_candidate)
+    sidecar_path = root / "canonical" / "expc" / f"{expc_cid.replace('::', '__')}__related_prec_ids.json"
+    sidecar_path.parent.mkdir(parents=True, exist_ok=True)
+    sidecar_path.write_text(json.dumps({"related_prec_ids": ["111", "999"]}), encoding="utf-8")
+
+    with caplog.at_level(logging.INFO, logger="src.export.legal_case_relation_builder"):
+        records = build_case_to_case_relation_records(raw_related_base_dir=raw_dir)
+
+    assert len(records) == 1
+    assert records[0]["source_case_type"] == "expc"
+
+    stat_logs = [m for m in caplog.messages if "expc->prec mapping stats" in m]
+    assert stat_logs, "mapping stats info 로그가 기록되어야 한다"
+    assert "success" in stat_logs[0]
+    assert "no_candidate" in stat_logs[0]

--- a/apps/backend/legal-pipeline/tests/test_legal_doc_collector_expc_filter.py
+++ b/apps/backend/legal-pipeline/tests/test_legal_doc_collector_expc_filter.py
@@ -1,0 +1,55 @@
+"""expc early pruning: _extract_expc_keyword / _is_relevant_expc_item 단위 테스트"""
+
+import pytest
+from src.collector.legal_doc_collector import _extract_expc_keyword, _is_relevant_expc_item
+
+
+class TestExtractExpcKeyword:
+    def test_strips_enforcement_decree_suffix(self):
+        assert _extract_expc_keyword("근로기준법 시행령") == "근로기준법"
+
+    def test_strips_enforcement_rule_suffix(self):
+        assert _extract_expc_keyword("근로기준법 시행규칙") == "근로기준법"
+
+    def test_strips_규칙_suffix(self):
+        assert _extract_expc_keyword("어떤법 규칙") == "어떤법"
+
+    def test_no_suffix_returns_first_token(self):
+        assert _extract_expc_keyword("남녀고용평등과 일·가정 양립 지원에 관한 법률") == "남녀고용평등과"
+
+    def test_single_word_law_name(self):
+        assert _extract_expc_keyword("근로기준법") == "근로기준법"
+
+    def test_enforcement_regulation_suffix(self):
+        assert _extract_expc_keyword("고용보험법 시행규정") == "고용보험법"
+
+
+class TestIsRelevantExpcItem:
+    def test_keyword_in_title_returns_true(self):
+        item = {"안건명": "민원인 - 근로기준법 제17조 관련 질의"}
+        assert _is_relevant_expc_item(item, "근로기준법 시행령") is True
+
+    def test_keyword_in_guillemet_title_returns_true(self):
+        item = {"안건명": "민원인 - (「근로기준법」 제17조 관련)"}
+        assert _is_relevant_expc_item(item, "근로기준법") is True
+
+    def test_unrelated_title_returns_false(self):
+        item = {"안건명": "민원인 - 체육시설의 설치·이용에 관한 법률 제31조 관련"}
+        assert _is_relevant_expc_item(item, "근로기준법 시행령") is False
+
+    def test_empty_title_passes_through(self):
+        # 제목 없는 항목은 하위 단계에서 처리하도록 통과
+        item = {"안건명": ""}
+        assert _is_relevant_expc_item(item, "근로기준법") is True
+
+    def test_missing_title_passes_through(self):
+        item = {}
+        assert _is_relevant_expc_item(item, "근로기준법") is True
+
+    def test_long_law_name_uses_first_token(self):
+        item = {"안건명": "남녀고용평등과 일·가정 양립 지원에 관한 법률 제19조 관련"}
+        assert _is_relevant_expc_item(item, "남녀고용평등과 일·가정 양립 지원에 관한 법률") is True
+
+    def test_non_expc_keyword_not_in_long_law_title_returns_false(self):
+        item = {"안건명": "산업안전보건법 제36조 관련 질의"}
+        assert _is_relevant_expc_item(item, "남녀고용평등과 일·가정 양립 지원에 관한 법률") is False

--- a/apps/backend/legal-pipeline/tests/test_legal_doc_collector_expc_filter.py
+++ b/apps/backend/legal-pipeline/tests/test_legal_doc_collector_expc_filter.py
@@ -1,7 +1,14 @@
 """expc early pruning: _extract_expc_keyword / _is_relevant_expc_item 단위 테스트"""
 
+import logging
+from unittest.mock import patch
+
 import pytest
-from src.collector.legal_doc_collector import _extract_expc_keyword, _is_relevant_expc_item
+from src.collector.legal_doc_collector import (
+    _extract_expc_keyword,
+    _is_relevant_expc_item,
+    collect_list_refs_for_law_name,
+)
 
 
 class TestExtractExpcKeyword:
@@ -53,3 +60,29 @@ class TestIsRelevantExpcItem:
     def test_non_expc_keyword_not_in_long_law_title_returns_false(self):
         item = {"안건명": "산업안전보건법 제36조 관련 질의"}
         assert _is_relevant_expc_item(item, "남녀고용평등과 일·가정 양립 지원에 관한 법률") is False
+
+
+def test_collect_list_refs_logs_expc_keyword_filtered_count(caplog):
+    """expc 키워드 필터 드롭이 별도 info 로그로 계측된다."""
+    relevant = {"안건명": "민원인 - 근로기준법 제17조 관련"}
+    irrelevant = {"안건명": "민원인 - 체육시설법 제31조 관련"}
+
+    with patch("src.collector.legal_doc_collector.fetch_list_page") as mock_fetch, \
+         patch("src.collector.legal_doc_collector.extract_list_items") as mock_items, \
+         caplog.at_level(logging.INFO, logger="src.collector.legal_doc_collector"):
+
+        mock_fetch.return_value = {}
+        mock_items.side_effect = [[relevant, irrelevant], []]
+
+        refs, filtered_out = collect_list_refs_for_law_name(
+            registry={}, oc="test", target="expc",
+            law_name="근로기준법 시행령", max_pages=2,
+        )
+
+    assert len(refs) == 1
+    assert filtered_out == 1
+
+    drop_logs = [m for m in caplog.messages if "expc keyword filter dropped=" in m]
+    assert drop_logs, "expc keyword filter 드롭 건수가 info 로그로 기록되어야 한다"
+    assert "dropped=1" in drop_logs[0]
+    assert "근로기준법 시행령" in drop_logs[0]

--- a/apps/backend/legal-pipeline/tests/test_legal_relation_builder.py
+++ b/apps/backend/legal-pipeline/tests/test_legal_relation_builder.py
@@ -339,3 +339,62 @@ def test_non_law_to_case_always_kept():
             "relation_confidence": 0.45,
         }
         assert _is_unverified_search_hit(row) is False, f"{model} should not be flagged"
+
+
+def test_build_legal_relation_records_logs_dropped_in_fallback_path(tmp_path, caplog):
+    """expanded fallback 경로에서 unverified search_hit 제거 시 warning 로그가 남는다."""
+    import logging
+
+    expanded_dir = tmp_path / "expanded" / "03_expanded_related_docs" / "근로기준법"
+    _write_jsonl(
+        expanded_dir / "relation_records.jsonl",
+        [
+            {
+                "id": "relation::case::prec::111::001",
+                "canonical_case_id": "case::prec::111",
+                "relation_model": "law_to_case",
+                "relation_types": ["search_hit"],
+                "body_verified": None,
+                "relation_confidence": 0.45,
+                "target": "prec",
+                "law_name": "근로기준법",
+                "source_law_name": "근로기준법",
+            },
+            {
+                "id": "relation::case::prec::222::001",
+                "canonical_case_id": "case::prec::222",
+                "relation_model": "law_to_case",
+                "relation_types": ["search_hit", "cited_law"],
+                "body_verified": True,
+                "target": "prec",
+                "law_name": "근로기준법",
+                "source_law_name": "근로기준법",
+            },
+        ],
+    )
+
+    with caplog.at_level(logging.WARNING, logger="src.export.legal_relation_builder"):
+        records = build_legal_relation_records(
+            expanded_base_dir=tmp_path / "expanded" / "03_expanded_related_docs"
+        )
+
+    assert len(records) == 1
+    assert records[0]["canonical_case_id"] == "case::prec::222"
+
+    drop_warnings = [m for m in caplog.messages if "dropped=" in m and "path=fallback" in m]
+    assert drop_warnings, "dropped 건수 warning이 기록되어야 한다"
+    assert "dropped=1" in drop_warnings[0]
+
+
+def test_build_legal_relation_records_logs_warning_when_raw_has_no_data(tmp_path, caplog):
+    """raw_related_base_dir을 전달했으나 데이터가 없을 때 fallback 진입 warning이 남는다."""
+    import logging
+
+    empty_raw_dir = tmp_path / "raw" / "02_related_legal_docs"
+    empty_raw_dir.mkdir(parents=True)
+
+    with caplog.at_level(logging.WARNING, logger="src.export.legal_relation_builder"):
+        build_legal_relation_records(raw_related_base_dir=empty_raw_dir)
+
+    fallback_warnings = [m for m in caplog.messages if "raw path had no data" in m]
+    assert fallback_warnings, "raw 데이터 없을 때 fallback 진입 warning이 기록되어야 한다"


### PR DESCRIPTION
## Work Description
- leagl_case 정합성 검증

## Changes
- 수집 과정중 datase 에 audit 추가 기록
- "동법", "~의 법" 이 teaget-law 인식된 노이즈 제거, 필터 개선
- 중점   ·와 ㆍ각각의 방식처리오 인한 같은법령 인섹 에러 수정
- 위 문제로 인한 root_name_id 인식누락 에러 수정
- expc 사례 및 관계 과수집 문제 해결

## 추가 발견 이슈
- 실제 사레 중 사례 제목, doc_nember 중복 데이터 존재
- prec(판례) : 69그룹 / 138건
- decc(행정심판례) : 35그룹 / 79건
- 수정, 개선 차이 같긴하나 명확한  구분 기준 찾기 어려움
- 현재는 수집은 중복 사례 까지, 관계 연결시에는 대표 사레만 연결
  
## Related Issue
close #181 
