### PR TITLE
[Refator] 그래프 2-hop(법령)추가 및 그래프 질의 무한루프 방지

### DIFF
--- a/apps/backend/api/src/routers/graph.py
+++ b/apps/backend/api/src/routers/graph.py
@@ -101,19 +101,22 @@ class GraphExpandResponse(BaseModel):
 
 
 # COLLECT로 관계별 리스트를 각각 수집 — OPTIONAL MATCH 카르테시안 곱 방지
+# [0..$limit] 슬라이싱으로 관계별 최대 건수를 제한해 대규모 fan-out 방지
 _EXPAND_CYPHER = """\
 MATCH (l:Law {law_name: $law_name})
 OPTIONAL MATCH (l)-[:HAS_CHILD_LAW]->(child:Law)
 WITH l,
-  COLLECT(DISTINCT {law_name: child.law_name, law_uid: child.law_uid, classified_level: child.classified_level}) AS child_laws
+  COLLECT(DISTINCT {law_name: child.law_name, law_uid: child.law_uid, classified_level: child.classified_level})[0..$limit] AS child_laws
 OPTIONAL MATCH (l)-[:DELEGATES_TO_LAW]->(delegated:Law)
 WITH l, child_laws,
-  COLLECT(DISTINCT {law_name: delegated.law_name, law_uid: delegated.law_uid, classified_level: delegated.classified_level}) AS delegated_laws
+  COLLECT(DISTINCT {law_name: delegated.law_name, law_uid: delegated.law_uid, classified_level: delegated.classified_level})[0..$limit] AS delegated_laws
 OPTIONAL MATCH (l)-[:REFERS_TO_LAW]->(referred:Law)
 WITH child_laws, delegated_laws,
-  COLLECT(DISTINCT {law_name: referred.law_name, law_uid: referred.law_uid, classified_level: referred.classified_level}) AS referred_laws
+  COLLECT(DISTINCT {law_name: referred.law_name, law_uid: referred.law_uid, classified_level: referred.classified_level})[0..$limit] AS referred_laws
 RETURN child_laws, delegated_laws, referred_laws
 """
+
+_EXPAND_LIMIT = 50
 
 
 def _parse_law_refs(items: list[dict]) -> list[LawRef]:
@@ -139,7 +142,7 @@ def graph_expand(
     관계 타입: HAS_CHILD_LAW(하위), DELEGATES_TO_LAW(위임), REFERS_TO_LAW(참조)
     """
     try:
-        rows = neo4j.run_query(_EXPAND_CYPHER, {"law_name": request.law_name})
+        rows = neo4j.run_query(_EXPAND_CYPHER, {"law_name": request.law_name, "limit": _EXPAND_LIMIT})
     except Neo4jClientError:
         logger.error("graph_expand Neo4j 실패", exc_info=True)
         return JSONResponse(

--- a/apps/backend/api/src/routers/graph.py
+++ b/apps/backend/api/src/routers/graph.py
@@ -1,7 +1,8 @@
 """그래프 라우터.
 
 엔드포인트:
-  POST /api/v1/graph/query - 자연어 질의 → Neo4j Cypher 실행 → 법령 구조 반환
+  POST /api/v1/graph/query  - 자연어 질의 → Neo4j Cypher 실행 → 법령 구조 반환
+  POST /api/v1/graph/expand - 법령 노드 클릭 시 연결 법령 직접 조회 (LLM 불필요)
 """
 
 from __future__ import annotations
@@ -77,4 +78,87 @@ def graph_query(
         relation_type=plan.relation_type,
         results=results,
         cypher=plan.cypher,
+    )
+
+
+# ── /expand ──────────────────────────────────────────────────────────────────
+
+class GraphExpandRequest(BaseModel):
+    law_name: str = Field(..., min_length=1, max_length=200, description="확장할 법령명")
+
+
+class LawRef(BaseModel):
+    law_name: str
+    law_uid: str | None
+    classified_level: str | None
+
+
+class GraphExpandResponse(BaseModel):
+    law_name: str
+    child_laws: list[LawRef]
+    delegated_laws: list[LawRef]
+    referred_laws: list[LawRef]
+
+
+# COLLECT로 관계별 리스트를 각각 수집 — OPTIONAL MATCH 카르테시안 곱 방지
+_EXPAND_CYPHER = """\
+MATCH (l:Law {law_name: $law_name})
+OPTIONAL MATCH (l)-[:HAS_CHILD_LAW]->(child:Law)
+WITH l,
+  COLLECT(DISTINCT {law_name: child.law_name, law_uid: child.law_uid, classified_level: child.classified_level}) AS child_laws
+OPTIONAL MATCH (l)-[:DELEGATES_TO_LAW]->(delegated:Law)
+WITH l, child_laws,
+  COLLECT(DISTINCT {law_name: delegated.law_name, law_uid: delegated.law_uid, classified_level: delegated.classified_level}) AS delegated_laws
+OPTIONAL MATCH (l)-[:REFERS_TO_LAW]->(referred:Law)
+WITH child_laws, delegated_laws,
+  COLLECT(DISTINCT {law_name: referred.law_name, law_uid: referred.law_uid, classified_level: referred.classified_level}) AS referred_laws
+RETURN child_laws, delegated_laws, referred_laws
+"""
+
+
+def _parse_law_refs(items: list[dict]) -> list[LawRef]:
+    return [
+        LawRef(
+            law_name=item["law_name"],
+            law_uid=item.get("law_uid"),
+            classified_level=item.get("classified_level"),
+        )
+        for item in (items or [])
+        if item.get("law_name")
+    ]
+
+
+@router.post("/expand", response_model=GraphExpandResponse)
+def graph_expand(
+    request: GraphExpandRequest,
+    neo4j: Neo4jClient = Depends(get_neo4j_client),
+) -> GraphExpandResponse:
+    """법령 노드 클릭 시 연결된 법령 간 관계를 직접 조회한다.
+
+    LLM 없이 Neo4j Cypher를 직접 실행하므로 지연 없이 즉시 응답한다.
+    관계 타입: HAS_CHILD_LAW(하위), DELEGATES_TO_LAW(위임), REFERS_TO_LAW(참조)
+    """
+    try:
+        rows = neo4j.run_query(_EXPAND_CYPHER, {"law_name": request.law_name})
+    except Neo4jClientError:
+        logger.error("graph_expand Neo4j 실패", exc_info=True)
+        return JSONResponse(
+            status_code=503,
+            content={"code": "GRAPH_EXPAND_ERROR", "error": "그래프 확장 조회 중 오류가 발생했습니다."},
+        )
+
+    if not rows:
+        return GraphExpandResponse(
+            law_name=request.law_name,
+            child_laws=[],
+            delegated_laws=[],
+            referred_laws=[],
+        )
+
+    row = rows[0]
+    return GraphExpandResponse(
+        law_name=request.law_name,
+        child_laws=_parse_law_refs(row.get("child_laws", [])),
+        delegated_laws=_parse_law_refs(row.get("delegated_laws", [])),
+        referred_laws=_parse_law_refs(row.get("referred_laws", [])),
     )

--- a/apps/backend/rag/rag_pipeline/graph/llm_cypher_planner.py
+++ b/apps/backend/rag/rag_pipeline/graph/llm_cypher_planner.py
@@ -44,9 +44,9 @@ _ALLOWED_RELS = frozenset({
 })
 # `[:TYPE]` 및 `[r:TYPE]`, `[r:TYPE*]` 등 변수·범위 포함 패턴 모두 캡처 (P1)
 _REL_RE = re.compile(r"\[(?:\w+\s*:\s*|:)(\w+)")
-# `*]` 또는 `*N..` 패턴: 상한 없는 가변 길이 경로 탐지
-# 허용: `*1..3`, `*..3` / 차단: `*]`, `*1..`, `*N`
-_UNBOUNDED_VAR_LEN_RE = re.compile(r"\*(?:\d+\.\.|\.\.)?]|\*\d*]")
+# 가변 길이 관계 패턴 전체 캡처: 타입 있음/없음, 변수 있음/없음 통합
+# 예) [*], [r*], [:TYPE*], [r:TYPE*1..3] → * 이후 범위 문자열을 group(1)으로 캡처
+_VAR_LEN_RE = re.compile(r"\[\w*(?::\w+)?\*([^\]]*)]")
 
 
 class CypherGuardError(ValueError):
@@ -77,25 +77,25 @@ class CypherGuard:
 
     @staticmethod
     def _validate_var_length(cypher: str) -> None:
-        # `[r:TYPE*N..M]` 패턴에서 상한 M 추출, 없거나 초과하면 차단
-        for m in re.finditer(r"\*(\d*)\.\.(\d*)]", cypher):
-            upper_str = m.group(2)
-            if not upper_str:
+        # 타입 있음/없음, 변수 있음/없음 모든 가변 길이 패턴 통합 검사
+        for m in _VAR_LEN_RE.finditer(cypher):
+            spec = m.group(1)  # * 이후 문자열: "", "3", "1..3", "1..", "..3"
+            if ".." in spec:
+                upper_str = spec.split("..")[-1]
+                if not upper_str:
+                    raise CypherGuardError(
+                        "unbounded variable-length path (*N..) is not allowed; "
+                        f"use *1..{CypherGuard._MAX_VAR_LEN_DEPTH}"
+                    )
+                if int(upper_str) > CypherGuard._MAX_VAR_LEN_DEPTH:
+                    raise CypherGuardError(
+                        f"variable-length path depth {upper_str} exceeds max "
+                        f"{CypherGuard._MAX_VAR_LEN_DEPTH}"
+                    )
+            else:
+                # "" (*단독) 또는 "3" (*N 단독) → 상한 없음
                 raise CypherGuardError(
-                    "unbounded variable-length path (*N..) is not allowed; "
-                    f"use *1..{CypherGuard._MAX_VAR_LEN_DEPTH}"
-                )
-            if int(upper_str) > CypherGuard._MAX_VAR_LEN_DEPTH:
-                raise CypherGuardError(
-                    f"variable-length path depth {upper_str} exceeds max "
-                    f"{CypherGuard._MAX_VAR_LEN_DEPTH}"
-                )
-        # `[r:TYPE*]` 또는 `[r:TYPE*N]` (상한 없는 단독 숫자) 차단
-        for m in re.finditer(r"\[(?:\w+\s*:\s*|:)\w+(\*(?:\d+)?)]", cypher):
-            spec = m.group(1)  # e.g. "*" or "*3"
-            if ".." not in spec:
-                raise CypherGuardError(
-                    f"unbounded variable-length path '{spec}' is not allowed; "
+                    f"unbounded variable-length path '*{spec}' is not allowed; "
                     f"use *1..{CypherGuard._MAX_VAR_LEN_DEPTH}"
                 )
 

--- a/apps/backend/rag/rag_pipeline/graph/llm_cypher_planner.py
+++ b/apps/backend/rag/rag_pipeline/graph/llm_cypher_planner.py
@@ -44,6 +44,9 @@ _ALLOWED_RELS = frozenset({
 })
 # `[:TYPE]` 및 `[r:TYPE]`, `[r:TYPE*]` 등 변수·범위 포함 패턴 모두 캡처 (P1)
 _REL_RE = re.compile(r"\[(?:\w+\s*:\s*|:)(\w+)")
+# `*]` 또는 `*N..` 패턴: 상한 없는 가변 길이 경로 탐지
+# 허용: `*1..3`, `*..3` / 차단: `*]`, `*1..`, `*N`
+_UNBOUNDED_VAR_LEN_RE = re.compile(r"\*(?:\d+\.\.|\.\.)?]|\*\d*]")
 
 
 class CypherGuardError(ValueError):
@@ -52,6 +55,8 @@ class CypherGuardError(ValueError):
 
 class CypherGuard:
     """실행 전 Cypher 안전성 검증 (injection/allowlist)."""
+
+    _MAX_VAR_LEN_DEPTH = 5
 
     @staticmethod
     def validate(cypher: str) -> None:
@@ -67,6 +72,32 @@ class CypherGuard:
                 raise CypherGuardError(f"forbidden relationship type: {rel}")
         if "MATCH" not in upper:
             raise CypherGuardError("query must contain at least one MATCH clause")
+        # 상한 없는 가변 길이 경로 차단 (순환 그래프에서 무한 탐색 방지)
+        CypherGuard._validate_var_length(cypher)
+
+    @staticmethod
+    def _validate_var_length(cypher: str) -> None:
+        # `[r:TYPE*N..M]` 패턴에서 상한 M 추출, 없거나 초과하면 차단
+        for m in re.finditer(r"\*(\d*)\.\.(\d*)]", cypher):
+            upper_str = m.group(2)
+            if not upper_str:
+                raise CypherGuardError(
+                    "unbounded variable-length path (*N..) is not allowed; "
+                    f"use *1..{CypherGuard._MAX_VAR_LEN_DEPTH}"
+                )
+            if int(upper_str) > CypherGuard._MAX_VAR_LEN_DEPTH:
+                raise CypherGuardError(
+                    f"variable-length path depth {upper_str} exceeds max "
+                    f"{CypherGuard._MAX_VAR_LEN_DEPTH}"
+                )
+        # `[r:TYPE*]` 또는 `[r:TYPE*N]` (상한 없는 단독 숫자) 차단
+        for m in re.finditer(r"\[(?:\w+\s*:\s*|:)\w+(\*(?:\d+)?)]", cypher):
+            spec = m.group(1)  # e.g. "*" or "*3"
+            if ".." not in spec:
+                raise CypherGuardError(
+                    f"unbounded variable-length path '{spec}' is not allowed; "
+                    f"use *1..{CypherGuard._MAX_VAR_LEN_DEPTH}"
+                )
 
 
 # ── 시스템 프롬프트 ────────────────────────────────────────────────────────────
@@ -90,6 +121,8 @@ _SYSTEM_PROMPT = """\
   - MATCH/OPTIONAL MATCH/WHERE/RETURN/ORDER BY/LIMIT/WITH만 허용
   - CREATE/MERGE/SET/DELETE/DETACH/DROP/CALL/LOAD/UNION/apoc.* 절대 금지
   - 파라미터는 반드시 $law_name, $article_no 형식 사용 (값 직접 삽입 금지)
+  - 가변 길이 경로 사용 시 반드시 상한 명시: *1..5 형식 (예: [:REFERS_TO_ARTICLE*1..3])
+    상한 없는 * 또는 *N.. 는 절대 금지 (그래프 순환으로 무한 탐색 발생)
   - 반드시 아래 JSON 형식만 출력 (설명/코드블록/마크다운 금지):
     {"cypher": "...", "params": {"law_name": "..."}}
 

--- a/apps/frontend/components/GraphNodeDetailPanel.tsx
+++ b/apps/frontend/components/GraphNodeDetailPanel.tsx
@@ -1,4 +1,4 @@
-import type { GraphEdge, GraphNode } from "@/lib/graph-types";
+import type { GraphEdge, GraphEdgeRelationType, GraphNode } from "@/lib/graph-types";
 
 interface GraphNodeDetailPanelProps {
   node: GraphNode;
@@ -19,21 +19,20 @@ const RELATION_LABEL: Record<string, string> = {
   structure: "구조",
 };
 
+const RELATION_ORDER: GraphEdgeRelationType[] = ["child_law", "delegation", "reference", "structure"];
+
 function formatParagraphNo(raw: string): string {
   const n = parseInt(raw, 10);
   if (!isNaN(n)) return `제${n}항`;
   return raw.startsWith("제") ? raw : `제${raw}항`;
 }
 
-function edgeCounterpartLabel(e: GraphEdge, nodeId: string, nodes: GraphNode[]): string {
-  const otherId = e.source === nodeId ? e.target : e.source;
-  const other = nodes.find((n) => n.id === otherId);
-  if (!other) return e.detail ?? "";
-  const direction = e.source === nodeId ? "→" : "←";
-  const name = other.articleNo
-    ? `${other.lawName ?? ""} ${other.articleNo}`.trim()
-    : (other.lawName ?? other.label);
-  return `${direction} ${name}`;
+function getNodeLabel(nodeId: string, nodes: GraphNode[]): string {
+  const found = nodes.find((n) => n.id === nodeId);
+  if (!found) return nodeId;
+  return found.articleNo
+    ? `${found.lawName ?? ""} ${found.articleNo}`.trim()
+    : (found.lawName ?? found.label);
 }
 
 export function GraphNodeDetailPanel({ node, edges, nodes, onClose }: GraphNodeDetailPanelProps) {
@@ -41,9 +40,10 @@ export function GraphNodeDetailPanel({ node, edges, nodes, onClose }: GraphNodeD
     (e) => e.source === node.id || e.target === node.id
   );
 
-  const refEdgesWithParagraphs = connectedEdges.filter(
-    (e) => e.relationType === "reference" && e.paragraphNos?.length
-  );
+  const grouped = RELATION_ORDER.flatMap((type) => {
+    const matching = connectedEdges.filter((e) => e.relationType === type);
+    return matching.length ? [{ type, edges: matching }] : [];
+  });
 
   return (
     <div className="shrink-0 border-t border-border max-h-[45%] flex flex-col">
@@ -91,41 +91,37 @@ export function GraphNodeDetailPanel({ node, edges, nodes, onClose }: GraphNodeD
           <p className="mt-0.5 text-xs text-muted-foreground">{node.articleNo}</p>
         )}
 
-        {/* 참조 항 정보 */}
-        {refEdgesWithParagraphs.length > 0 && (
-          <div className="mt-2 border-t border-border/60 pt-2">
-            <p className="text-[10px] font-medium text-muted-foreground mb-1">참조 항</p>
-            {refEdgesWithParagraphs.map((e) => (
-              <div key={e.id} className="flex flex-wrap gap-1">
-                {e.paragraphNos!.map((p) => (
-                  <span
-                    key={p}
-                    className="rounded bg-primary/8 px-1.5 py-0.5 text-[10px] text-primary"
-                  >
-                    {formatParagraphNo(p)}
-                  </span>
-                ))}
-              </div>
-            ))}
-          </div>
-        )}
-
-        {/* 연결 관계 목록 */}
-        {connectedEdges.length > 0 && (
-          <div className="mt-2 border-t border-border/60 pt-2">
-            <p className="text-[10px] font-medium text-muted-foreground mb-1">연결 관계</p>
-            <div className="flex flex-col gap-0.5">
-              {connectedEdges.map((e) => (
-                <div key={e.id} className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
-                  <span className="rounded bg-muted px-1 py-0.5 text-[9px] font-medium shrink-0">
-                    {RELATION_LABEL[e.relationType] ?? e.relationType}
-                  </span>
-                  <span className="truncate">{edgeCounterpartLabel(e, node.id, nodes)}</span>
+        {/* 관계 타입별 그룹 */}
+        {grouped.map(({ type, edges: groupEdges }) => (
+          <div key={type} className="mt-2 border-t border-border/60 pt-2">
+            <p className="text-[10px] font-medium text-muted-foreground mb-1">
+              {RELATION_LABEL[type] ?? type}
+            </p>
+            <div className="flex flex-col gap-1.5">
+              {groupEdges.map((e) => (
+                <div key={e.id}>
+                  <div className="flex items-center gap-1 text-[10px] text-muted-foreground min-w-0">
+                    <span className="truncate shrink min-w-0">{getNodeLabel(e.source, nodes)}</span>
+                    <span className="shrink-0 text-muted-foreground/50">→</span>
+                    <span className="truncate shrink min-w-0">{getNodeLabel(e.target, nodes)}</span>
+                  </div>
+                  {e.paragraphNos?.length ? (
+                    <div className="flex flex-wrap gap-1 mt-0.5">
+                      {e.paragraphNos.map((p) => (
+                        <span
+                          key={p}
+                          className="rounded bg-primary/8 px-1.5 py-0.5 text-[10px] text-primary"
+                        >
+                          {formatParagraphNo(p)}
+                        </span>
+                      ))}
+                    </div>
+                  ) : null}
                 </div>
               ))}
             </div>
           </div>
-        )}
+        ))}
       </div>
     </div>
   );

--- a/apps/frontend/components/LawGraphPanel.tsx
+++ b/apps/frontend/components/LawGraphPanel.tsx
@@ -7,6 +7,20 @@ import { expandNode, queryGraph } from "@/lib/api-client";
 import { buildVisDatasets, expandResponseToGraphParts, mergeGraphData, toGraphData } from "@/lib/graph-adapter";
 import type { GraphNode, LawGraphData } from "@/lib/graph-types";
 
+function applyReferenceFilter(graphData: LawGraphData, showReference: boolean): LawGraphData {
+  if (showReference) return graphData;
+  const visibleEdges = graphData.edges.filter((e) => e.relationType !== "reference");
+  const connectedIds = new Set([
+    graphData.centerNodeId,
+    ...visibleEdges.flatMap((e) => [e.source, e.target]),
+  ]);
+  return {
+    ...graphData,
+    nodes: graphData.nodes.filter((n) => connectedIds.has(n.id)),
+    edges: visibleEdges,
+  };
+}
+
 interface LawGraphPanelProps {
   lastQuery: string;
   queryKey: number;
@@ -60,6 +74,7 @@ export function LawGraphPanel({ lastQuery, queryKey, isActive, onNodeSelect, onG
   // click handler stale closure 방지용 ref
   const graphDataRef = useRef<LawGraphData | null>(null);
   const onNodeSelectRef = useRef(onNodeSelect);
+  const selectedNodeIdRef = useRef<string | null>(null);
   // expand 시 fit 억제 플래그
   const isExpandRef = useRef(false);
   // 이미 expand된 노드 ID 추적 (새 질의 시 초기화)
@@ -69,6 +84,7 @@ export function LawGraphPanel({ lastQuery, queryKey, isActive, onNodeSelect, onG
 
   const [state, setState] = useState<PanelState>("idle");
   const [graphData, setGraphData] = useState<LawGraphData | null>(null);
+  const [showReference, setShowReference] = useState(false);
   const lastSuccessKey = useRef<number>(-1);
   const requestToken = useRef<number>(0);
   const abortRef = useRef<AbortController | null>(null);
@@ -96,10 +112,12 @@ export function LawGraphPanel({ lastQuery, queryKey, isActive, onNodeSelect, onG
 
     network.on("click", (params) => {
       if (params.nodes.length === 0) {
+        selectedNodeIdRef.current = null;
         onNodeSelectRef.current(null);
         return;
       }
       const nodeId = params.nodes[0] as string;
+      selectedNodeIdRef.current = nodeId;
       const found = graphDataRef.current?.nodes.find((n) => n.id === nodeId) ?? null;
       onNodeSelectRef.current(found);
 
@@ -130,6 +148,7 @@ export function LawGraphPanel({ lastQuery, queryKey, isActive, onNodeSelect, onG
     setGraphData(null);
     graphDataRef.current = null;
     expandedNodesRef.current = new Set();
+    selectedNodeIdRef.current = null;
     onGraphDataChange?.(null);
     onNodeSelectRef.current(null);
 
@@ -159,23 +178,29 @@ export function LawGraphPanel({ lastQuery, queryKey, isActive, onNodeSelect, onG
     return () => { controller.abort(); };
   }, [isActive, queryKey, lastQuery, onGraphDataChange]);
 
-  // graphData 변경 시 DataSet 전체 갱신
-  // expand 시 setGraphData(merged)로 진입하므로 clear+add 방식으로 동기화
+  // graphData/showReference 변경 시 DataSet 전체 갱신
   useEffect(() => {
     if (!graphData || !nodesDataSetRef.current || !edgesDataSetRef.current) return;
 
-    const { nodes, edges } = buildVisDatasets(graphData);
+    const filtered = applyReferenceFilter(graphData, showReference);
+    const { nodes, edges } = buildVisDatasets(filtered);
     nodesDataSetRef.current.clear();
     edgesDataSetRef.current.clear();
     nodesDataSetRef.current.add(nodes.get());
     edgesDataSetRef.current.add(edges.get());
 
-    // expand 시에는 뷰포트 유지, 새 질의에만 fit
+    // 토글로 선택 노드가 숨겨졌으면 선택 초기화
+    if (selectedNodeIdRef.current && !filtered.nodes.some((n) => n.id === selectedNodeIdRef.current)) {
+      selectedNodeIdRef.current = null;
+      onNodeSelectRef.current(null);
+    }
+
+    // expand 시에는 뷰포트 유지, 새 질의/토글에는 fit
     if (!isExpandRef.current) {
       networkRef.current?.fit();
     }
     isExpandRef.current = false;
-  }, [graphData]);
+  }, [graphData, showReference]);
 
   // expand 핸들러 — 렌더마다 최신 상태를 ref에 동기화
   handleExpandRef.current = (node: GraphNode) => {
@@ -220,6 +245,19 @@ export function LawGraphPanel({ lastQuery, queryKey, isActive, onNodeSelect, onG
           <h2 className="text-sm font-semibold text-foreground">법령 관계 그래프</h2>
           {state === "loading" && (
             <Loader2 className="ml-auto h-3.5 w-3.5 animate-spin text-muted-foreground" />
+          )}
+          {state === "success" && (
+            <button
+              type="button"
+              onClick={() => setShowReference((v) => !v)}
+              className={`ml-auto rounded border px-2 py-0.5 text-[10px] transition-colors ${
+                showReference
+                  ? "border-primary/30 bg-primary/10 text-primary"
+                  : "border-border text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              참조 {showReference ? "ON" : "OFF"}
+            </button>
           )}
         </div>
       </div>

--- a/apps/frontend/components/LawGraphPanel.tsx
+++ b/apps/frontend/components/LawGraphPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Network as NetworkIcon, Loader2, AlertCircle, BarChart3 } from "lucide-react";
+import { DataSet } from "vis-data";
 import { Network } from "vis-network";
 import type { Options } from "vis-network";
 import { queryGraph } from "@/lib/api-client";
@@ -48,21 +49,67 @@ const VIS_OPTIONS: Options = {
   },
 };
 
-
 export function LawGraphPanel({ lastQuery, queryKey, isActive, onNodeSelect, onGraphDataChange }: LawGraphPanelProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const networkRef = useRef<Network | null>(null);
+  // DataSet을 ref로 관리 — expand 시 add()로 증분 추가
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const nodesDataSetRef = useRef<DataSet<any> | null>(null);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const edgesDataSetRef = useRef<DataSet<any> | null>(null);
+  // click handler stale closure 방지용 ref
+  const graphDataRef = useRef<LawGraphData | null>(null);
+  const onNodeSelectRef = useRef(onNodeSelect);
+
   const [state, setState] = useState<PanelState>("idle");
   const [graphData, setGraphData] = useState<LawGraphData | null>(null);
-  const lastSuccessKey = useRef<number>(-1);  // 성공한 queryKey만 기록
-  const requestToken = useRef<number>(0);     // 요청 순서 토큰
+  const lastSuccessKey = useRef<number>(-1);
+  const requestToken = useRef<number>(0);
   const abortRef = useRef<AbortController | null>(null);
 
-  // 그래프 탭 활성화 + 새 질문(queryKey 변경)이 있을 때 API 호출
+  // onNodeSelect가 바뀌면 ref 동기화
+  useEffect(() => {
+    onNodeSelectRef.current = onNodeSelect;
+  }, [onNodeSelect]);
+
+  // Network 초기화 — 마운트 시 한 번만 생성, DataSet은 재사용
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const nodesDS = new DataSet<object>([]);
+    const edgesDS = new DataSet<object>([]);
+    nodesDataSetRef.current = nodesDS;
+    edgesDataSetRef.current = edgesDS;
+
+    const network = new Network(
+      containerRef.current,
+      { nodes: nodesDS, edges: edgesDS },
+      VIS_OPTIONS,
+    );
+    networkRef.current = network;
+
+    network.on("click", (params) => {
+      if (params.nodes.length === 0) {
+        onNodeSelectRef.current(null);
+        return;
+      }
+      const nodeId = params.nodes[0] as string;
+      const found = graphDataRef.current?.nodes.find((n) => n.id === nodeId) ?? null;
+      onNodeSelectRef.current(found);
+    });
+
+    return () => {
+      network.destroy();
+      networkRef.current = null;
+      nodesDataSetRef.current = null;
+      edgesDataSetRef.current = null;
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // 새 질의 — API 호출 후 graphData 교체
   useEffect(() => {
     if (!isActive || !lastQuery || queryKey === lastSuccessKey.current) return;
 
-    // 이전 요청 중단
     abortRef.current?.abort();
     const controller = new AbortController();
     abortRef.current = controller;
@@ -70,8 +117,9 @@ export function LawGraphPanel({ lastQuery, queryKey, isActive, onNodeSelect, onG
 
     setState("loading");
     setGraphData(null);
+    graphDataRef.current = null;
     onGraphDataChange?.(null);
-    onNodeSelect(null);
+    onNodeSelectRef.current(null);
 
     queryGraph(lastQuery, controller.signal)
       .then((resp) => {
@@ -81,7 +129,8 @@ export function LawGraphPanel({ lastQuery, queryKey, isActive, onNodeSelect, onG
           setState("empty");
           return;
         }
-        lastSuccessKey.current = queryKey;  // 성공 시에만 기록
+        lastSuccessKey.current = queryKey;
+        graphDataRef.current = data;
         setGraphData(data);
         onGraphDataChange?.(data);
         setState("success");
@@ -96,33 +145,19 @@ export function LawGraphPanel({ lastQuery, queryKey, isActive, onNodeSelect, onG
       });
 
     return () => { controller.abort(); };
-  }, [isActive, queryKey, lastQuery, onNodeSelect]);
+  }, [isActive, queryKey, lastQuery, onGraphDataChange]);
 
-  // graphData가 바뀔 때 vis-network 렌더링
+  // graphData 변경 시 DataSet 갱신 — 새 질의는 clear 후 교체, expand는 add만
   useEffect(() => {
-    if (!containerRef.current || !graphData) return;
-
-    networkRef.current?.destroy();
+    if (!graphData || !nodesDataSetRef.current || !edgesDataSetRef.current) return;
 
     const { nodes, edges } = buildVisDatasets(graphData);
-    const network = new Network(containerRef.current, { nodes, edges }, VIS_OPTIONS);
-    networkRef.current = network;
-
-    network.on("click", (params) => {
-      if (params.nodes.length === 0) {
-        onNodeSelect(null);
-        return;
-      }
-      const nodeId = params.nodes[0] as string;
-      const found = graphData.nodes.find((n) => n.id === nodeId) ?? null;
-      onNodeSelect(found);
-    });
-
-    return () => {
-      network.destroy();
-      networkRef.current = null;
-    };
-  }, [graphData, onNodeSelect]);
+    nodesDataSetRef.current.clear();
+    edgesDataSetRef.current.clear();
+    nodesDataSetRef.current.add(nodes.get());
+    edgesDataSetRef.current.add(edges.get());
+    networkRef.current?.fit();
+  }, [graphData]);
 
   return (
     <div className="flex h-full flex-col">
@@ -137,14 +172,13 @@ export function LawGraphPanel({ lastQuery, queryKey, isActive, onNodeSelect, onG
       </div>
 
       <div className="relative flex-1 overflow-hidden">
-        {/* vis-network 컨테이너 — success일 때만 표시 */}
+        {/* vis-network 컨테이너 — 항상 마운트, display로 표시/숨김 제어 */}
         <div
           ref={containerRef}
           className="absolute inset-0"
           style={{ display: state === "success" ? "block" : "none" }}
         />
 
-        {/* 상태별 안내 메시지 */}
         {state !== "success" && (
           <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
             {state === "idle" && (

--- a/apps/frontend/components/LawGraphPanel.tsx
+++ b/apps/frontend/components/LawGraphPanel.tsx
@@ -202,6 +202,7 @@ export function LawGraphPanel({ lastQuery, queryKey, isActive, onNodeSelect, onG
         graphDataRef.current = merged;
         isExpandRef.current = true;   // fit 억제
         setGraphData(merged);
+        onGraphDataChange?.(merged);
       })
       .catch(() => {
         // 실패 시 expandedNodes에서 제거해 재시도 가능하게 유지

--- a/apps/frontend/components/LawGraphPanel.tsx
+++ b/apps/frontend/components/LawGraphPanel.tsx
@@ -1,10 +1,9 @@
 import { useEffect, useRef, useState } from "react";
 import { Network as NetworkIcon, Loader2, AlertCircle, BarChart3 } from "lucide-react";
-import { DataSet } from "vis-data";
 import { Network } from "vis-network";
 import type { Options } from "vis-network";
 import { queryGraph } from "@/lib/api-client";
-import { toGraphData } from "@/lib/graph-adapter";
+import { buildVisDatasets, toGraphData } from "@/lib/graph-adapter";
 import type { GraphNode, LawGraphData } from "@/lib/graph-types";
 
 interface LawGraphPanelProps {
@@ -49,49 +48,6 @@ const VIS_OPTIONS: Options = {
   },
 };
 
-function lawNodeColor(lawType: string | undefined) {
-  switch (lawType) {
-    case "시행령":
-      return { background: "hsl(217, 75%, 86%)", border: "hsl(217, 55%, 65%)", highlight: { background: "hsl(217, 75%, 79%)", border: "hsl(217, 55%, 55%)" } };
-    case "시행규칙":
-      return { background: "hsl(217, 55%, 82%)", border: "hsl(217, 40%, 62%)", highlight: { background: "hsl(217, 55%, 75%)", border: "hsl(217, 40%, 52%)" } };
-    case "법":
-    default:
-      return { background: "hsl(217, 91%, 92%)", border: "hsl(217, 60%, 70%)", highlight: { background: "hsl(217, 91%, 85%)", border: "hsl(217, 60%, 60%)" } };
-  }
-}
-
-function buildVisDatasets(graphData: LawGraphData) {
-  const visNodes = graphData.nodes.map((n) => ({
-    id: n.id,
-    label: n.label,
-    size: n.isCenter ? 28 : 18,
-    color: n.isCenter
-      ? { background: "hsl(217, 91%, 50%)", border: "hsl(217, 91%, 40%)", highlight: { background: "hsl(217, 91%, 45%)", border: "hsl(217, 91%, 35%)" } }
-      : n.kind === "law"
-        ? lawNodeColor(n.lawType)
-        : { background: "hsl(142, 71%, 93%)", border: "hsl(142, 60%, 65%)", highlight: { background: "hsl(142, 71%, 86%)", border: "hsl(142, 60%, 55%)" } },
-    font: { color: n.isCenter ? "hsl(217, 91%, 30%)" : "hsl(220, 30%, 20%)", size: n.isCenter ? 13 : 12 },
-  }));
-
-  const visEdges = graphData.edges.map((e) => ({
-    id: e.id,
-    from: e.source,
-    to: e.target,
-    label: e.relationType === "child_law"
-      ? "하위"
-      : e.relationType === "delegation"
-        ? "위임"
-        : e.relationType === "reference"
-          ? (e.paragraphNos?.length ? `참조 · 제${parseInt(e.paragraphNos[0], 10) || e.paragraphNos[0]}항` : "참조")
-          : "",
-  }));
-
-  return {
-    nodes: new DataSet(visNodes),
-    edges: new DataSet(visEdges),
-  };
-}
 
 export function LawGraphPanel({ lastQuery, queryKey, isActive, onNodeSelect, onGraphDataChange }: LawGraphPanelProps) {
   const containerRef = useRef<HTMLDivElement>(null);

--- a/apps/frontend/components/LawGraphPanel.tsx
+++ b/apps/frontend/components/LawGraphPanel.tsx
@@ -3,8 +3,8 @@ import { Network as NetworkIcon, Loader2, AlertCircle, BarChart3 } from "lucide-
 import { DataSet } from "vis-data";
 import { Network } from "vis-network";
 import type { Options } from "vis-network";
-import { queryGraph } from "@/lib/api-client";
-import { buildVisDatasets, toGraphData } from "@/lib/graph-adapter";
+import { expandNode, queryGraph } from "@/lib/api-client";
+import { buildVisDatasets, expandResponseToGraphParts, mergeGraphData, toGraphData } from "@/lib/graph-adapter";
 import type { GraphNode, LawGraphData } from "@/lib/graph-types";
 
 interface LawGraphPanelProps {
@@ -60,6 +60,12 @@ export function LawGraphPanel({ lastQuery, queryKey, isActive, onNodeSelect, onG
   // click handler stale closure 방지용 ref
   const graphDataRef = useRef<LawGraphData | null>(null);
   const onNodeSelectRef = useRef(onNodeSelect);
+  // expand 시 fit 억제 플래그
+  const isExpandRef = useRef(false);
+  // 이미 expand된 노드 ID 추적 (새 질의 시 초기화)
+  const expandedNodesRef = useRef<Set<string>>(new Set());
+  // expand 핸들러 (최신 상태를 ref로 유지하여 click handler stale closure 방지)
+  const handleExpandRef = useRef<(node: GraphNode) => void>(() => {});
 
   const [state, setState] = useState<PanelState>("idle");
   const [graphData, setGraphData] = useState<LawGraphData | null>(null);
@@ -96,6 +102,11 @@ export function LawGraphPanel({ lastQuery, queryKey, isActive, onNodeSelect, onG
       const nodeId = params.nodes[0] as string;
       const found = graphDataRef.current?.nodes.find((n) => n.id === nodeId) ?? null;
       onNodeSelectRef.current(found);
+
+      // 법령 노드 + hop < 2 + 미확장 → expand
+      if (found?.kind === "law" && (found.hop ?? 0) < 2 && !expandedNodesRef.current.has(nodeId)) {
+        handleExpandRef.current(found);
+      }
     });
 
     return () => {
@@ -118,6 +129,7 @@ export function LawGraphPanel({ lastQuery, queryKey, isActive, onNodeSelect, onG
     setState("loading");
     setGraphData(null);
     graphDataRef.current = null;
+    expandedNodesRef.current = new Set();
     onGraphDataChange?.(null);
     onNodeSelectRef.current(null);
 
@@ -147,7 +159,8 @@ export function LawGraphPanel({ lastQuery, queryKey, isActive, onNodeSelect, onG
     return () => { controller.abort(); };
   }, [isActive, queryKey, lastQuery, onGraphDataChange]);
 
-  // graphData 변경 시 DataSet 갱신 — 새 질의는 clear 후 교체, expand는 add만
+  // graphData 변경 시 DataSet 전체 갱신
+  // expand 시 setGraphData(merged)로 진입하므로 clear+add 방식으로 동기화
   useEffect(() => {
     if (!graphData || !nodesDataSetRef.current || !edgesDataSetRef.current) return;
 
@@ -156,8 +169,41 @@ export function LawGraphPanel({ lastQuery, queryKey, isActive, onNodeSelect, onG
     edgesDataSetRef.current.clear();
     nodesDataSetRef.current.add(nodes.get());
     edgesDataSetRef.current.add(edges.get());
-    networkRef.current?.fit();
+
+    // expand 시에는 뷰포트 유지, 새 질의에만 fit
+    if (!isExpandRef.current) {
+      networkRef.current?.fit();
+    }
+    isExpandRef.current = false;
   }, [graphData]);
+
+  // expand 핸들러 — 렌더마다 최신 상태를 ref에 동기화
+  handleExpandRef.current = (node: GraphNode) => {
+    if (!node.lawName) return;
+    expandedNodesRef.current.add(node.id);
+
+    // 클릭된 노드를 로딩 색상으로 표시
+    nodesDataSetRef.current?.update({ id: node.id, color: { background: "hsl(217, 80%, 78%)", border: "hsl(217, 60%, 58%)" } });
+
+    expandNode(node.lawName)
+      .then((resp) => {
+        const current = graphDataRef.current;
+        if (!current) return;
+
+        const { nodes: newNodes, edges: newEdges } = expandResponseToGraphParts(resp, node.id);
+        const merged = mergeGraphData(current, newNodes, newEdges, node.hop ?? 0);
+
+        graphDataRef.current = merged;
+        isExpandRef.current = true;   // fit 억제
+        setGraphData(merged);
+      })
+      .catch(() => {
+        // 실패 시 expandedNodes에서 제거해 재시도 가능하게 유지
+        expandedNodesRef.current.delete(node.id);
+        // 원래 색상 복원 (DataSet 갱신 없이 노드 색상만 원복)
+        nodesDataSetRef.current?.update({ id: node.id, color: undefined });
+      });
+  };
 
   return (
     <div className="flex h-full flex-col">

--- a/apps/frontend/components/LawGraphPanel.tsx
+++ b/apps/frontend/components/LawGraphPanel.tsx
@@ -180,6 +180,8 @@ export function LawGraphPanel({ lastQuery, queryKey, isActive, onNodeSelect, onG
   // expand 핸들러 — 렌더마다 최신 상태를 ref에 동기화
   handleExpandRef.current = (node: GraphNode) => {
     if (!node.lawName) return;
+    // 호출 시점의 queryKey 캡처 — 응답 도착 시 세대 검증에 사용
+    const capturedQueryKey = lastSuccessKey.current;
     expandedNodesRef.current.add(node.id);
 
     // 클릭된 노드를 로딩 색상으로 표시
@@ -189,6 +191,10 @@ export function LawGraphPanel({ lastQuery, queryKey, isActive, onNodeSelect, onG
       .then((resp) => {
         const current = graphDataRef.current;
         if (!current) return;
+        // stale 응답 차단: 새 질의가 시작됐으면 무시
+        if (lastSuccessKey.current !== capturedQueryKey) return;
+        // 고아 엣지 방지: sourceNode가 현재 그래프에 없으면 무시
+        if (!current.nodes.some((n) => n.id === node.id)) return;
 
         const { nodes: newNodes, edges: newEdges } = expandResponseToGraphParts(resp, node.id);
         const merged = mergeGraphData(current, newNodes, newEdges, node.hop ?? 0);
@@ -200,7 +206,7 @@ export function LawGraphPanel({ lastQuery, queryKey, isActive, onNodeSelect, onG
       .catch(() => {
         // 실패 시 expandedNodes에서 제거해 재시도 가능하게 유지
         expandedNodesRef.current.delete(node.id);
-        // 원래 색상 복원 (DataSet 갱신 없이 노드 색상만 원복)
+        // 원래 색상 복원
         nodesDataSetRef.current?.update({ id: node.id, color: undefined });
       });
   };

--- a/apps/frontend/lib/api-client.ts
+++ b/apps/frontend/lib/api-client.ts
@@ -175,13 +175,24 @@ export async function getSuggestions(request: {
 
 // ── Graph ─────────────────────────────────────────────────────────────────────
 
-export type { GraphQueryResponse } from "./graph-types";
+export type { GraphQueryResponse, GraphExpandResponse } from "./graph-types";
 
 export async function queryGraph(query: string, signal?: AbortSignal): Promise<import("./graph-types").GraphQueryResponse> {
   const res = await fetch(`${getApiBaseUrl()}/api/v1/graph/query`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ query }),
+    signal,
+  });
+  if (!res.ok) await throwApiError(res);
+  return res.json();
+}
+
+export async function expandNode(lawName: string, signal?: AbortSignal): Promise<import("./graph-types").GraphExpandResponse> {
+  const res = await fetch(`${getApiBaseUrl()}/api/v1/graph/expand`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ law_name: lawName }),
     signal,
   });
   if (!res.ok) await throwApiError(res);

--- a/apps/frontend/lib/graph-adapter.ts
+++ b/apps/frontend/lib/graph-adapter.ts
@@ -1,4 +1,75 @@
+import { DataSet } from "vis-data";
 import type { GraphEdge, GraphEdgeRelationType, GraphNode, GraphQueryResponse, LawGraphData } from "./graph-types";
+
+// ── vis-network 색상 헬퍼 ─────────────────────────────────────────────────────
+
+function lawNodeColor(lawType: string | undefined) {
+  switch (lawType) {
+    case "시행령":
+      return { background: "hsl(217, 75%, 86%)", border: "hsl(217, 55%, 65%)", highlight: { background: "hsl(217, 75%, 79%)", border: "hsl(217, 55%, 55%)" } };
+    case "시행규칙":
+      return { background: "hsl(217, 55%, 82%)", border: "hsl(217, 40%, 62%)", highlight: { background: "hsl(217, 55%, 75%)", border: "hsl(217, 40%, 52%)" } };
+    case "법":
+    default:
+      return { background: "hsl(217, 91%, 92%)", border: "hsl(217, 60%, 70%)", highlight: { background: "hsl(217, 91%, 85%)", border: "hsl(217, 60%, 60%)" } };
+  }
+}
+
+export function buildVisDatasets(graphData: LawGraphData) {
+  const visNodes = graphData.nodes.map((n) => ({
+    id: n.id,
+    label: n.label,
+    size: n.isCenter ? 28 : 18,
+    color: n.isCenter
+      ? { background: "hsl(217, 91%, 50%)", border: "hsl(217, 91%, 40%)", highlight: { background: "hsl(217, 91%, 45%)", border: "hsl(217, 91%, 35%)" } }
+      : n.kind === "law"
+        ? lawNodeColor(n.lawType)
+        : { background: "hsl(142, 71%, 93%)", border: "hsl(142, 60%, 65%)", highlight: { background: "hsl(142, 71%, 86%)", border: "hsl(142, 60%, 55%)" } },
+    font: { color: n.isCenter ? "hsl(217, 91%, 30%)" : "hsl(220, 30%, 20%)", size: n.isCenter ? 13 : 12 },
+  }));
+
+  const visEdges = graphData.edges.map((e) => ({
+    id: e.id,
+    from: e.source,
+    to: e.target,
+    label: e.relationType === "child_law"
+      ? "하위"
+      : e.relationType === "delegation"
+        ? "위임"
+        : e.relationType === "reference"
+          ? (e.paragraphNos?.length ? `참조 · 제${parseInt(e.paragraphNos[0], 10) || e.paragraphNos[0]}항` : "참조")
+          : "",
+  }));
+
+  return {
+    nodes: new DataSet(visNodes),
+    edges: new DataSet(visEdges),
+  };
+}
+
+// ── 그래프 병합 (expand 시 증분 추가) ─────────────────────────────────────────
+
+export function mergeGraphData(
+  existing: LawGraphData,
+  newNodes: GraphNode[],
+  newEdges: GraphEdge[],
+  sourceHop: number,
+): LawGraphData {
+  const seenNodes = new Set(existing.nodes.map((n) => n.id));
+  const seenEdges = new Set(existing.edges.map((e) => e.id));
+
+  const addedNodes = newNodes
+    .filter((n) => !seenNodes.has(n.id))
+    .map((n) => ({ ...n, hop: sourceHop + 1 }));
+
+  const addedEdges = newEdges.filter((e) => !seenEdges.has(e.id));
+
+  return {
+    ...existing,
+    nodes: [...existing.nodes, ...addedNodes],
+    edges: [...existing.edges, ...addedEdges],
+  };
+}
 
 export function toGraphData(resp: GraphQueryResponse): LawGraphData | null {
   if (!resp.law_name || !resp.results.length) return null;
@@ -18,6 +89,7 @@ export function toGraphData(resp: GraphQueryResponse): LawGraphData | null {
         lawName: resp.law_name,
         articleNo: resp.article_no,
         isCenter: true,
+        hop: 0,
       }
     : {
         id: centerId,
@@ -25,6 +97,7 @@ export function toGraphData(resp: GraphQueryResponse): LawGraphData | null {
         kind: "law",
         lawName: resp.law_name,
         isCenter: true,
+        hop: 0,
       };
 
   const nodes: GraphNode[] = [centerNode];

--- a/apps/frontend/lib/graph-adapter.ts
+++ b/apps/frontend/lib/graph-adapter.ts
@@ -1,5 +1,5 @@
 import { DataSet } from "vis-data";
-import type { GraphEdge, GraphEdgeRelationType, GraphNode, GraphQueryResponse, LawGraphData } from "./graph-types";
+import type { GraphEdge, GraphEdgeRelationType, GraphExpandResponse, GraphNode, GraphQueryResponse, LawGraphData, LawRef } from "./graph-types";
 
 // ── vis-network 색상 헬퍼 ─────────────────────────────────────────────────────
 
@@ -16,17 +16,26 @@ function lawNodeColor(lawType: string | undefined) {
 }
 
 export function buildVisDatasets(graphData: LawGraphData) {
-  const visNodes = graphData.nodes.map((n) => ({
-    id: n.id,
-    label: n.label,
-    size: n.isCenter ? 28 : 18,
-    color: n.isCenter
-      ? { background: "hsl(217, 91%, 50%)", border: "hsl(217, 91%, 40%)", highlight: { background: "hsl(217, 91%, 45%)", border: "hsl(217, 91%, 35%)" } }
-      : n.kind === "law"
-        ? lawNodeColor(n.lawType)
-        : { background: "hsl(142, 71%, 93%)", border: "hsl(142, 60%, 65%)", highlight: { background: "hsl(142, 71%, 86%)", border: "hsl(142, 60%, 55%)" } },
-    font: { color: n.isCenter ? "hsl(217, 91%, 30%)" : "hsl(220, 30%, 20%)", size: n.isCenter ? 13 : 12 },
-  }));
+  const visNodes = graphData.nodes.map((n) => {
+    const isGhosted = (n.hop ?? 0) >= 2;
+    return {
+      id: n.id,
+      label: n.label,
+      size: n.isCenter ? 28 : 18,
+      color: n.isCenter
+        ? { background: "hsl(217, 91%, 50%)", border: "hsl(217, 91%, 40%)", highlight: { background: "hsl(217, 91%, 45%)", border: "hsl(217, 91%, 35%)" } }
+        : isGhosted
+          ? { background: "hsl(217, 40%, 95%)", border: "hsl(217, 30%, 82%)", highlight: { background: "hsl(217, 40%, 90%)", border: "hsl(217, 30%, 75%)" } }
+          : n.kind === "law"
+            ? lawNodeColor(n.lawType)
+            : { background: "hsl(142, 71%, 93%)", border: "hsl(142, 60%, 65%)", highlight: { background: "hsl(142, 71%, 86%)", border: "hsl(142, 60%, 55%)" } },
+      font: {
+        color: n.isCenter ? "hsl(217, 91%, 30%)" : isGhosted ? "hsl(220, 20%, 65%)" : "hsl(220, 30%, 20%)",
+        size: n.isCenter ? 13 : 12,
+      },
+      borderDashes: isGhosted ? [4, 2] : false,
+    };
+  });
 
   const visEdges = graphData.edges.map((e) => ({
     id: e.id,
@@ -69,6 +78,41 @@ export function mergeGraphData(
     nodes: [...existing.nodes, ...addedNodes],
     edges: [...existing.edges, ...addedEdges],
   };
+}
+
+// ── expand API 응답 → GraphNode[], GraphEdge[] 변환 ───────────────────────────
+
+function _addLawRef(
+  ref: LawRef,
+  relationType: GraphEdgeRelationType,
+  sourceNodeId: string,
+  nodes: GraphNode[],
+  edges: GraphEdge[],
+  seenIds: Set<string>,
+) {
+  if (!ref.law_name) return;
+  const id = ref.law_uid ?? `law:${ref.law_name}`;
+  if (!seenIds.has(id)) {
+    seenIds.add(id);
+    nodes.push({ id, label: ref.law_name, kind: "law", lawName: ref.law_name, lawType: ref.classified_level ?? undefined });
+  }
+  // 같은 소스-타겟이라도 관계 타입이 다르면 별도 엣지
+  edges.push({ id: `${sourceNodeId}->${id}::${relationType}`, source: sourceNodeId, target: id, relationType });
+}
+
+export function expandResponseToGraphParts(
+  resp: GraphExpandResponse,
+  sourceNodeId: string,
+): { nodes: GraphNode[]; edges: GraphEdge[] } {
+  const nodes: GraphNode[] = [];
+  const edges: GraphEdge[] = [];
+  const seenIds = new Set<string>();
+
+  for (const ref of resp.child_laws) _addLawRef(ref, "child_law", sourceNodeId, nodes, edges, seenIds);
+  for (const ref of resp.delegated_laws) _addLawRef(ref, "delegation", sourceNodeId, nodes, edges, seenIds);
+  for (const ref of resp.referred_laws) _addLawRef(ref, "reference", sourceNodeId, nodes, edges, seenIds);
+
+  return { nodes, edges };
 }
 
 export function toGraphData(resp: GraphQueryResponse): LawGraphData | null {

--- a/apps/frontend/lib/graph-adapter.ts
+++ b/apps/frontend/lib/graph-adapter.ts
@@ -91,7 +91,7 @@ function _addLawRef(
   seenIds: Set<string>,
 ) {
   if (!ref.law_name) return;
-  const id = ref.law_uid ?? `law:${ref.law_name}`;
+  const id = `law:${ref.law_name}`;
   if (!seenIds.has(id)) {
     seenIds.add(id);
     nodes.push({ id, label: ref.law_name, kind: "law", lawName: ref.law_name, lawType: ref.classified_level ?? undefined });
@@ -156,30 +156,27 @@ export function toGraphData(resp: GraphQueryResponse): LawGraphData | null {
     switch (relationType) {
       case "child_law": {
         const name = row.child_law_name as string | null;
-        const uid = row.child_law_uid as string | null;
         const level = row.classified_level as string | null;
         if (!name) continue;
-        const id = uid ?? `law:${name}`;
+        const id = `law:${name}`;
         targetNode = { id, label: name, kind: "law", lawName: name, lawType: level ?? undefined };
         break;
       }
       case "delegation": {
         const name = row.target_law_name as string | null;
-        const uid = row.target_law_uid as string | null;
         const level = row.classified_level as string | null;
         if (!name) continue;
-        const id = uid ?? `law:${name}`;
+        const id = `law:${name}`;
         targetNode = { id, label: name, kind: "law", lawName: name, lawType: level ?? undefined };
         break;
       }
       case "reference": {
         const refType = row.ref_type as string | null;
         const refName = row.ref_name as string | null;
-        const refUid = row.ref_uid as string | null;
         const refArticleNo = row.ref_article_no as string | null;
         if (!refName) continue;
         if (refType === "article" && refArticleNo) {
-          const id = refUid ?? `article:${refName}:${refArticleNo}`;
+          const id = `article:${refName}:${refArticleNo}`;
           const srcArticleNo = row.src_article_no as string | null;
           const paragraphNos = row.ref_paragraph_nos as string[] | null;
           targetNode = {
@@ -193,16 +190,15 @@ export function toGraphData(resp: GraphQueryResponse): LawGraphData | null {
           edgeParagraphNos = paragraphNos ?? undefined;
         } else {
           const level = row.ref_classified_level as string | null;
-          const id = refUid ?? `law:${refName}`;
+          const id = `law:${refName}`;
           targetNode = { id, label: refName, kind: "law", lawName: refName, lawType: level ?? undefined };
         }
         break;
       }
       case "structure": {
         const articleNo = row.article_no as string | null;
-        const articleUid = row.article_uid as string | null;
         if (!articleNo) continue;
-        const id = articleUid ?? `article:${resp.law_name}:${articleNo}`;
+        const id = `article:${resp.law_name}:${articleNo}`;
         targetNode = {
           id,
           label: articleNo,

--- a/apps/frontend/lib/graph-adapter.ts
+++ b/apps/frontend/lib/graph-adapter.ts
@@ -159,7 +159,7 @@ export function toGraphData(resp: GraphQueryResponse): LawGraphData | null {
         const level = row.classified_level as string | null;
         if (!name) continue;
         const id = `law:${name}`;
-        targetNode = { id, label: name, kind: "law", lawName: name, lawType: level ?? undefined };
+        targetNode = { id, label: name, kind: "law", lawName: name, lawType: level ?? undefined, hop: 1 };
         break;
       }
       case "delegation": {
@@ -167,7 +167,7 @@ export function toGraphData(resp: GraphQueryResponse): LawGraphData | null {
         const level = row.classified_level as string | null;
         if (!name) continue;
         const id = `law:${name}`;
-        targetNode = { id, label: name, kind: "law", lawName: name, lawType: level ?? undefined };
+        targetNode = { id, label: name, kind: "law", lawName: name, lawType: level ?? undefined, hop: 1 };
         break;
       }
       case "reference": {
@@ -185,13 +185,14 @@ export function toGraphData(resp: GraphQueryResponse): LawGraphData | null {
             kind: "article",
             lawName: refName,
             articleNo: refArticleNo,
+            hop: 1,
           };
           edgeDetail = srcArticleNo && refArticleNo ? `${srcArticleNo} → ${refArticleNo}` : undefined;
           edgeParagraphNos = paragraphNos ?? undefined;
         } else {
           const level = row.ref_classified_level as string | null;
           const id = `law:${refName}`;
-          targetNode = { id, label: refName, kind: "law", lawName: refName, lawType: level ?? undefined };
+          targetNode = { id, label: refName, kind: "law", lawName: refName, lawType: level ?? undefined, hop: 1 };
         }
         break;
       }
@@ -205,6 +206,7 @@ export function toGraphData(resp: GraphQueryResponse): LawGraphData | null {
           kind: "article",
           lawName: resp.law_name,
           articleNo,
+          hop: 1,
         };
         break;
       }

--- a/apps/frontend/lib/graph-types.ts
+++ b/apps/frontend/lib/graph-types.ts
@@ -38,3 +38,16 @@ export type GraphQueryResponse = {
   results: Record<string, unknown>[];
   cypher?: string;
 };
+
+export type LawRef = {
+  law_name: string;
+  law_uid: string | null;
+  classified_level: string | null;
+};
+
+export type GraphExpandResponse = {
+  law_name: string;
+  child_laws: LawRef[];
+  delegated_laws: LawRef[];
+  referred_laws: LawRef[];
+};

--- a/apps/frontend/lib/graph-types.ts
+++ b/apps/frontend/lib/graph-types.ts
@@ -8,6 +8,7 @@ export type GraphNode = {
   lawType?: string;    // "법" | "시행령" | "시행규칙" | "규정" 등
   articleNo?: string;
   isCenter?: boolean;
+  hop?: number;        // 0=중심, 1=1차확장, 2=2차확장(expand 불가)
 };
 
 export type GraphEdgeRelationType = "child_law" | "delegation" | "reference" | "structure";


### PR DESCRIPTION
## Work Description
- 기존 1-hop 관계는 단순함
- 기존 검색결과 출력 그래프는 유지
- 2-hop 관계는 노드 클릭으로 확장(lazy expend)
- 클릭 확장은 법령만 해당, 조문 까지 확장되면 복잡도 증가
- vis-network 지속사용  그래프 뷰어는 참고용,
- 복잡한 관계는 이후 하이브리드 검색과정에 포함됨, 프론트와 관련 X

## Changes
### 확장 규칙
- hop=0 (초기 중심 노드) : 클릭 → 법령 간 관계 추가
- hop=1 (1차 확장 노드) : 클릭 → 법령 간 관계 추가
- hop=2 (2차 확장 노드) : 확장 X, detail panel 만
- 최대 50 노드로 제한(복잡성 방지)
### 변경 내역
- 백엔드 expand API 추가 
  - POST /api/v1/graph/expand
- detail-pannel 가독성 이슈 수정 

## Related Issue
close #184
