### PR TITLE
Refactor/neo4j case

### DIFF
--- a/apps/backend/legal-pipeline/scripts/seed_law_graph_neo4j.py
+++ b/apps/backend/legal-pipeline/scripts/seed_law_graph_neo4j.py
@@ -56,6 +56,7 @@ def main() -> None:
     with driver.session(database=neo4j_database) as session:
         session.run("CREATE CONSTRAINT law_uid_unique IF NOT EXISTS FOR (n:Law) REQUIRE n.law_uid IS UNIQUE")
         session.run("CREATE CONSTRAINT article_uid_unique IF NOT EXISTS FOR (n:Article) REQUIRE n.article_uid IS UNIQUE")
+        session.run("CREATE CONSTRAINT case_canonical_case_id_unique IF NOT EXISTS FOR (n:Case) REQUIRE n.canonical_case_id IS UNIQUE")
         for query, payload_rows in iter_seed_operations(rows):
             for batch in _batched(payload_rows, args.batch_size):
                 if not batch:

--- a/apps/backend/legal-pipeline/src/export/law_graph_exporter.py
+++ b/apps/backend/legal-pipeline/src/export/law_graph_exporter.py
@@ -21,6 +21,13 @@ def _edge_id(prefix: str, source: str, target: str) -> str:
     return f"{prefix}::{source}::{target}"
 
 
+def _case_edge_id(prefix: str, relation_id: Any, source: str, target: str) -> str:
+    relation_id_text = str(relation_id or "").strip()
+    if relation_id_text:
+        return f"{prefix}::{relation_id_text}"
+    return _edge_id(prefix, source, target)
+
+
 def _clean_str(value: Any) -> str | None:
     text = str(value or "").strip()
     return text or None
@@ -52,6 +59,62 @@ def _merge_string_list(existing: list[str] | None, new_values: list[str] | None)
         merged.append(text)
 
     return merged
+
+
+def _case_node_from_row(row: dict[str, Any]) -> dict[str, Any] | None:
+    canonical_case_id = _clean_str(row.get("canonical_case_id") or row.get("canonical_id"))
+    if not canonical_case_id:
+        return None
+
+    doc_type = _clean_str(row.get("doc_type") if row.get("doc_type") != "relation" else row.get("target"))
+    return {
+        "node_type": "Case",
+        "canonical_case_id": canonical_case_id,
+        "doc_type": doc_type,
+        "doc_type_label": row.get("doc_type_label"),
+        "title": row.get("title"),
+        "doc_number": row.get("doc_number"),
+        "decision_date": row.get("decision_date"),
+        "doc_id": row.get("doc_id"),
+        "detail_link": row.get("detail_link"),
+        "source_file_path": row.get("source_file_path"),
+    }
+
+
+def _target_case_node_from_relation(row: dict[str, Any]) -> dict[str, Any] | None:
+    canonical_case_id = _clean_str(row.get("target_canonical_case_id"))
+    if not canonical_case_id:
+        return None
+
+    return {
+        "node_type": "Case",
+        "canonical_case_id": canonical_case_id,
+        "doc_type": row.get("target_target") or row.get("target_case_type"),
+        "doc_type_label": row.get("target_doc_type_label"),
+        "title": row.get("target_title"),
+        "doc_number": row.get("target_doc_number"),
+        "decision_date": None,
+        "doc_id": row.get("target_doc_id"),
+        "detail_link": None,
+        "source_file_path": None,
+    }
+
+
+def _merge_case_node(case_nodes: dict[str, dict[str, Any]], candidate: dict[str, Any] | None) -> None:
+    if not candidate:
+        return
+    canonical_case_id = str(candidate.get("canonical_case_id") or "").strip()
+    if not canonical_case_id:
+        return
+
+    current = case_nodes.get(canonical_case_id)
+    if current is None:
+        case_nodes[canonical_case_id] = dict(candidate)
+        return
+
+    for key, value in candidate.items():
+        if value not in (None, "", []) and current.get(key) in (None, "", []):
+            current[key] = value
 
 
 def _normalized_law_level(row: dict[str, Any]) -> str:
@@ -578,6 +641,103 @@ def _upsert_refers_to_article_edge(
     current["reference_texts"] = _merge_string_list(current.get("reference_texts"), [reference_text])
 
 
+def _case_edge_common(row: dict[str, Any], edge_id: str, edge_type: str) -> dict[str, Any]:
+    return {
+        "edge_id": edge_id,
+        "edge_type": edge_type,
+        "relation_id": row.get("id"),
+        "relation_model": row.get("relation_model"),
+        "relation_type": row.get("relation_type"),
+        "relation_types": row.get("relation_types") or [],
+        "relation_confidence": row.get("relation_confidence"),
+        "resolution_status": row.get("resolution_status"),
+        "source_group": row.get("source_group"),
+        "source_file_path": row.get("source_file_path"),
+        "evidence_preview": row.get("evidence_preview"),
+        "referenced_case_number": row.get("referenced_case_number"),
+        "reference_sources": row.get("reference_sources") or [],
+    }
+
+
+def _build_case_graph_from_relations(
+    *,
+    legal_relations_path: Path,
+    case_nodes: dict[str, dict[str, Any]],
+    law_nodes: dict[str, dict[str, Any]],
+    article_nodes: dict[str, dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    case_related_to_law_edges: dict[str, dict[str, Any]] = {}
+    case_related_to_article_edges: dict[str, dict[str, Any]] = {}
+    case_cites_case_edges: dict[str, dict[str, Any]] = {}
+
+    for row in _iter_jsonl(legal_relations_path):
+        relation_model = str(row.get("relation_model") or "").strip()
+        source_case_id = _clean_str(row.get("source_canonical_case_id") or row.get("canonical_case_id"))
+
+        if relation_model == "law_to_case":
+            if not source_case_id:
+                continue
+            _merge_case_node(case_nodes, _case_node_from_row(row))
+
+            law_uid = _clean_str(row.get("law_uid") or row.get("source_law_uid"))
+            if law_uid and law_uid in law_nodes:
+                edge_id = _case_edge_id("CASE_RELATED_TO_LAW", row.get("id"), source_case_id, law_uid)
+                case_related_to_law_edges.setdefault(
+                    edge_id,
+                    {
+                        **_case_edge_common(row, edge_id, "RELATED_TO_LAW"),
+                        "source_canonical_case_id": source_case_id,
+                        "target_law_uid": law_uid,
+                        "target_law_name": row.get("law_name") or row.get("source_law_name"),
+                        "article_keys": row.get("article_keys") or [],
+                        "article_no_displays": row.get("article_no_displays") or [],
+                    },
+                )
+
+            for article_key in [str(item).strip() for item in (row.get("article_keys") or []) if str(item).strip()]:
+                article_uid = _article_uid(law_uid, article_key)
+                if not article_uid or article_uid not in article_nodes:
+                    continue
+                edge_id = _case_edge_id("CASE_RELATED_TO_ARTICLE", f"{row.get('id')}::{article_key}", source_case_id, article_uid)
+                case_related_to_article_edges.setdefault(
+                    edge_id,
+                    {
+                        **_case_edge_common(row, edge_id, "RELATED_TO_ARTICLE"),
+                        "source_canonical_case_id": source_case_id,
+                        "target_article_uid": article_uid,
+                        "target_law_uid": law_uid,
+                        "target_article_key": article_key,
+                    },
+                )
+
+        elif relation_model == "case_to_case":
+            target_case_id = _clean_str(row.get("target_canonical_case_id"))
+            if not source_case_id or not target_case_id:
+                continue
+
+            _merge_case_node(case_nodes, _case_node_from_row(row))
+            _merge_case_node(case_nodes, _target_case_node_from_relation(row))
+
+            edge_id = _case_edge_id("CASE_CITES_CASE", row.get("id"), source_case_id, target_case_id)
+            case_cites_case_edges.setdefault(
+                edge_id,
+                {
+                    **_case_edge_common(row, edge_id, "CITES_CASE"),
+                    "source_canonical_case_id": source_case_id,
+                    "target_canonical_case_id": target_case_id,
+                    "source_case_type": row.get("source_case_type"),
+                    "target_case_type": row.get("target_case_type"),
+                    "relation_subtype": row.get("relation_subtype"),
+                },
+            )
+
+    return (
+        sorted(case_related_to_law_edges.values(), key=lambda row: str(row.get("edge_id") or "")),
+        sorted(case_related_to_article_edges.values(), key=lambda row: str(row.get("edge_id") or "")),
+        sorted(case_cites_case_edges.values(), key=lambda row: str(row.get("edge_id") or "")),
+    )
+
+
 def build_law_graph_export_rows(
     *,
     legal_corpus_path: str | Path = "data/dataset/legal_corpus.jsonl",
@@ -588,6 +748,7 @@ def build_law_graph_export_rows(
 
     law_nodes: dict[str, dict[str, Any]] = {}
     article_nodes: dict[str, dict[str, Any]] = {}
+    case_nodes: dict[str, dict[str, Any]] = {}
     has_article_edges: dict[str, dict[str, Any]] = {}
     has_child_law_edges: list[dict[str, Any]] = []
     delegates_to_law_edges: list[dict[str, Any]] = []
@@ -597,6 +758,10 @@ def build_law_graph_export_rows(
     seen_article_keys_by_law: dict[str, set[str]] = {}
 
     for row in _iter_jsonl(legal_corpus_path):
+        if str(row.get("doc_type") or "").strip() in {"prec", "detc", "expc", "decc"}:
+            _merge_case_node(case_nodes, _case_node_from_row(row))
+            continue
+
         if str(row.get("doc_type") or "").strip() != "law":
             continue
         if str(row.get("section_type") or "").strip() != "article":
@@ -830,14 +995,25 @@ def build_law_graph_export_rows(
                 target_article_details=[],
             )
 
+    case_related_to_law_edges, case_related_to_article_edges, case_cites_case_edges = _build_case_graph_from_relations(
+        legal_relations_path=legal_relations_path,
+        case_nodes=case_nodes,
+        law_nodes=law_nodes,
+        article_nodes=article_nodes,
+    )
+
     return {
         "law_nodes": sorted(law_nodes.values(), key=lambda row: str(row.get("law_uid") or "")),
         "article_nodes": sorted(article_nodes.values(), key=lambda row: str(row.get("article_uid") or "")),
+        "case_nodes": sorted(case_nodes.values(), key=lambda row: str(row.get("canonical_case_id") or "")),
         "has_article_edges": sorted(has_article_edges.values(), key=lambda row: str(row.get("edge_id") or "")),
         "has_child_law_edges": has_child_law_edges,
         "delegates_to_law_edges": delegates_to_law_edges,
         "refers_to_law_edges": sorted(refers_to_law_edges.values(), key=lambda row: str(row.get("edge_id") or "")),
         "refers_to_article_edges": sorted(refers_to_article_edges.values(), key=lambda row: str(row.get("edge_id") or "")),
+        "case_related_to_law_edges": case_related_to_law_edges,
+        "case_related_to_article_edges": case_related_to_article_edges,
+        "case_cites_case_edges": case_cites_case_edges,
     }
 
 
@@ -855,20 +1031,28 @@ def write_law_graph_export(
 
     write_jsonl(rows["law_nodes"], output_dir / "graph_law_nodes.jsonl")
     write_jsonl(rows["article_nodes"], output_dir / "graph_article_nodes.jsonl")
+    write_jsonl(rows["case_nodes"], output_dir / "graph_case_nodes.jsonl")
     write_jsonl(rows["has_article_edges"], output_dir / "graph_edges_has_article.jsonl")
     write_jsonl(rows["has_child_law_edges"], output_dir / "graph_edges_has_child_law.jsonl")
     write_jsonl(rows["delegates_to_law_edges"], output_dir / "graph_edges_delegates_to_law.jsonl")
     write_jsonl(rows["refers_to_law_edges"], output_dir / "graph_edges_refers_to_law.jsonl")
     write_jsonl(rows["refers_to_article_edges"], output_dir / "graph_edges_refers_to_article.jsonl")
+    write_jsonl(rows["case_related_to_law_edges"], output_dir / "graph_edges_case_related_to_law.jsonl")
+    write_jsonl(rows["case_related_to_article_edges"], output_dir / "graph_edges_case_related_to_article.jsonl")
+    write_jsonl(rows["case_cites_case_edges"], output_dir / "graph_edges_case_cites_case.jsonl")
 
     manifest = {
         "law_node_count": len(rows["law_nodes"]),
         "article_node_count": len(rows["article_nodes"]),
+        "case_node_count": len(rows["case_nodes"]),
         "has_article_edge_count": len(rows["has_article_edges"]),
         "has_child_law_edge_count": len(rows["has_child_law_edges"]),
         "delegates_to_law_edge_count": len(rows["delegates_to_law_edges"]),
         "refers_to_law_edge_count": len(rows["refers_to_law_edges"]),
         "refers_to_article_edge_count": len(rows["refers_to_article_edges"]),
+        "case_related_to_law_edge_count": len(rows["case_related_to_law_edges"]),
+        "case_related_to_article_edge_count": len(rows["case_related_to_article_edges"]),
+        "case_cites_case_edge_count": len(rows["case_cites_case_edges"]),
         "source_legal_corpus_path": str(legal_corpus_path),
         "source_legal_relations_path": str(legal_relations_path),
     }

--- a/apps/backend/legal-pipeline/src/export/law_graph_neo4j_seed.py
+++ b/apps/backend/legal-pipeline/src/export/law_graph_neo4j_seed.py
@@ -13,11 +13,15 @@ def load_graph_seed_rows(
     return {
         "law_nodes": list(_iter_jsonl(base_dir / "graph_law_nodes.jsonl")),
         "article_nodes": list(_iter_jsonl(base_dir / "graph_article_nodes.jsonl")),
+        "case_nodes": list(_iter_jsonl(base_dir / "graph_case_nodes.jsonl")),
         "has_article_edges": list(_iter_jsonl(base_dir / "graph_edges_has_article.jsonl")),
         "has_child_law_edges": list(_iter_jsonl(base_dir / "graph_edges_has_child_law.jsonl")),
         "delegates_to_law_edges": list(_iter_jsonl(base_dir / "graph_edges_delegates_to_law.jsonl")),
         "refers_to_law_edges": list(_iter_jsonl(base_dir / "graph_edges_refers_to_law.jsonl")),
         "refers_to_article_edges": list(_iter_jsonl(base_dir / "graph_edges_refers_to_article.jsonl")),
+        "case_related_to_law_edges": list(_iter_jsonl(base_dir / "graph_edges_case_related_to_law.jsonl")),
+        "case_related_to_article_edges": list(_iter_jsonl(base_dir / "graph_edges_case_related_to_article.jsonl")),
+        "case_cites_case_edges": list(_iter_jsonl(base_dir / "graph_edges_case_cites_case.jsonl")),
     }
 
 
@@ -25,11 +29,15 @@ def build_seed_manifest(rows: dict[str, list[dict[str, Any]]]) -> dict[str, int]
     return {
         "law_node_count": len(rows["law_nodes"]),
         "article_node_count": len(rows["article_nodes"]),
+        "case_node_count": len(rows["case_nodes"]),
         "has_article_edge_count": len(rows["has_article_edges"]),
         "has_child_law_edge_count": len(rows["has_child_law_edges"]),
         "delegates_to_law_edge_count": len(rows["delegates_to_law_edges"]),
         "refers_to_law_edge_count": len(rows["refers_to_law_edges"]),
         "refers_to_article_edge_count": len(rows["refers_to_article_edges"]),
+        "case_related_to_law_edge_count": len(rows["case_related_to_law_edges"]),
+        "case_related_to_article_edge_count": len(rows["case_related_to_article_edges"]),
+        "case_cites_case_edge_count": len(rows["case_cites_case_edges"]),
     }
 
 
@@ -42,6 +50,12 @@ SET n += row
 ARTICLE_NODE_QUERY = """
 UNWIND $rows AS row
 MERGE (n:Article {article_uid: row.article_uid})
+SET n += row
+""".strip()
+
+CASE_NODE_QUERY = """
+UNWIND $rows AS row
+MERGE (n:Case {canonical_case_id: row.canonical_case_id})
 SET n += row
 """.strip()
 
@@ -85,14 +99,42 @@ MERGE (source)-[r:REFERS_TO_ARTICLE {edge_id: row.edge_id}]->(target)
 SET r += row
 """.strip()
 
+CASE_RELATED_TO_LAW_QUERY = """
+UNWIND $rows AS row
+MATCH (source:Case {canonical_case_id: row.source_canonical_case_id})
+MATCH (target:Law {law_uid: row.target_law_uid})
+MERGE (source)-[r:RELATED_TO_LAW {edge_id: row.edge_id}]->(target)
+SET r += row
+""".strip()
+
+CASE_RELATED_TO_ARTICLE_QUERY = """
+UNWIND $rows AS row
+MATCH (source:Case {canonical_case_id: row.source_canonical_case_id})
+MATCH (target:Article {article_uid: row.target_article_uid})
+MERGE (source)-[r:RELATED_TO_ARTICLE {edge_id: row.edge_id}]->(target)
+SET r += row
+""".strip()
+
+CASE_CITES_CASE_QUERY = """
+UNWIND $rows AS row
+MATCH (source:Case {canonical_case_id: row.source_canonical_case_id})
+MATCH (target:Case {canonical_case_id: row.target_canonical_case_id})
+MERGE (source)-[r:CITES_CASE {edge_id: row.edge_id}]->(target)
+SET r += row
+""".strip()
+
 
 def iter_seed_operations(rows: dict[str, list[dict[str, Any]]]) -> list[tuple[str, list[dict[str, Any]]]]:
     return [
         (LAW_NODE_QUERY, rows["law_nodes"]),
         (ARTICLE_NODE_QUERY, rows["article_nodes"]),
+        (CASE_NODE_QUERY, rows["case_nodes"]),
         (HAS_ARTICLE_QUERY, rows["has_article_edges"]),
         (HAS_CHILD_LAW_QUERY, rows["has_child_law_edges"]),
         (DELEGATES_TO_LAW_QUERY, rows["delegates_to_law_edges"]),
         (REFERS_TO_LAW_QUERY, rows["refers_to_law_edges"]),
         (REFERS_TO_ARTICLE_QUERY, rows["refers_to_article_edges"]),
+        (CASE_RELATED_TO_LAW_QUERY, rows["case_related_to_law_edges"]),
+        (CASE_RELATED_TO_ARTICLE_QUERY, rows["case_related_to_article_edges"]),
+        (CASE_CITES_CASE_QUERY, rows["case_cites_case_edges"]),
     ]

--- a/apps/backend/legal-pipeline/tests/test_law_graph_exporter.py
+++ b/apps/backend/legal-pipeline/tests/test_law_graph_exporter.py
@@ -109,6 +109,132 @@ def test_build_law_graph_export_rows_dedupes_article_nodes_and_builds_reference_
     assert "explicit_law_name" in law_edge["relation_types"]
 
 
+def test_build_law_graph_export_rows_builds_case_nodes_and_case_relation_edges(tmp_path):
+    corpus_path = tmp_path / "dataset" / "legal_corpus.jsonl"
+    relations_path = tmp_path / "dataset" / "legal_relations.jsonl"
+
+    write_jsonl(
+        [
+            {
+                "id": "law::001::article::6::0",
+                "doc_type": "law",
+                "section_type": "article",
+                "law_uid": "001",
+                "law_name": "최저임금법",
+                "root_law_uid": "001",
+                "root_law_name": "최저임금법",
+                "classified_level": "법",
+                "kind_name": "법률",
+                "article_key": "6",
+                "article_no_display": "제6조",
+                "text": "최저임금 조문",
+                "display_text": "최저임금 조문",
+                "source_file_path": "law.json",
+            },
+            {
+                "id": "case_chunk::case::detc::180923::0",
+                "canonical_case_id": "case::detc::180923",
+                "canonical_id": "case::detc::180923",
+                "doc_type": "detc",
+                "doc_type_label": "헌재결정례",
+                "title": "최저임금법 제6조 제5항 위헌소원",
+                "doc_number": "2020헌바11",
+                "decision_date": "20230525",
+                "doc_id": "180923",
+                "detail_link": "/DRF/lawService.do?target=detc&ID=180923",
+                "source_file_path": "case.json",
+                "chunk_index": 0,
+                "text": "첫 청크",
+            },
+            {
+                "id": "case_chunk::case::detc::180923::1",
+                "canonical_case_id": "case::detc::180923",
+                "canonical_id": "case::detc::180923",
+                "doc_type": "detc",
+                "doc_type_label": "헌재결정례",
+                "chunk_index": 1,
+                "text": "둘째 청크",
+            },
+        ],
+        corpus_path,
+    )
+    write_jsonl(
+        [
+            {
+                "id": "relation::case::detc::180923::001",
+                "canonical_case_id": "case::detc::180923",
+                "canonical_id": "case::detc::180923",
+                "relation_model": "law_to_case",
+                "relation_type": "related_law",
+                "relation_types": ["search_hit", "related_law"],
+                "relation_confidence": 0.98,
+                "resolution_status": "resolved",
+                "doc_type": "relation",
+                "doc_type_label": "헌재결정례",
+                "target": "detc",
+                "title": "최저임금법 제6조 제5항 위헌소원",
+                "doc_number": "2020헌바11",
+                "law_uid": "001",
+                "law_name": "최저임금법",
+                "article_keys": ["6"],
+                "article_no_displays": ["제6조"],
+                "source_group": "03_expanded_related_docs",
+                "source_file_path": "relation.json",
+            },
+            {
+                "id": "case_relation::case::detc::180923::case::prec::1",
+                "canonical_case_id": "case::detc::180923",
+                "source_canonical_case_id": "case::detc::180923",
+                "target_canonical_case_id": "case::prec::1",
+                "relation_model": "case_to_case",
+                "relation_type": "cited_case",
+                "relation_types": ["cited_case"],
+                "relation_confidence": 0.95,
+                "resolution_status": "resolved",
+                "doc_type": "relation",
+                "doc_type_label": "헌재결정례",
+                "target": "detc",
+                "title": "최저임금법 제6조 제5항 위헌소원",
+                "doc_number": "2020헌바11",
+                "target_target": "prec",
+                "target_doc_type_label": "판례",
+                "target_title": "임금",
+                "target_doc_number": "2016다2451",
+                "referenced_case_number": "2016다2451",
+                "source_group": "04_case_to_case_relations",
+            },
+        ],
+        relations_path,
+    )
+
+    rows = build_law_graph_export_rows(
+        legal_corpus_path=corpus_path,
+        legal_relations_path=relations_path,
+    )
+
+    assert [row["canonical_case_id"] for row in rows["case_nodes"]] == [
+        "case::detc::180923",
+        "case::prec::1",
+    ]
+    source_case = rows["case_nodes"][0]
+    assert source_case["doc_type"] == "detc"
+    assert source_case["title"] == "최저임금법 제6조 제5항 위헌소원"
+
+    assert len(rows["case_related_to_law_edges"]) == 1
+    law_edge = rows["case_related_to_law_edges"][0]
+    assert law_edge["source_canonical_case_id"] == "case::detc::180923"
+    assert law_edge["target_law_uid"] == "001"
+
+    assert len(rows["case_related_to_article_edges"]) == 1
+    article_edge = rows["case_related_to_article_edges"][0]
+    assert article_edge["target_article_uid"] == "article::001::6"
+
+    assert len(rows["case_cites_case_edges"]) == 1
+    case_edge = rows["case_cites_case_edges"][0]
+    assert case_edge["source_canonical_case_id"] == "case::detc::180923"
+    assert case_edge["target_canonical_case_id"] == "case::prec::1"
+
+
 def test_build_law_graph_export_rows_skips_blank_law_name_and_restores_root_law_name(tmp_path):
     corpus_path = tmp_path / "dataset" / "legal_corpus.jsonl"
     relations_path = tmp_path / "dataset" / "legal_relations.jsonl"
@@ -613,10 +739,18 @@ def test_write_law_graph_export_writes_manifest_and_files(tmp_path):
 
     assert manifest["law_node_count"] == 1
     assert manifest["article_node_count"] == 1
+    assert manifest["case_node_count"] == 0
     assert manifest["has_child_law_edge_count"] == 0
     assert manifest["delegates_to_law_edge_count"] == 0
+    assert manifest["case_related_to_law_edge_count"] == 0
+    assert manifest["case_related_to_article_edge_count"] == 0
+    assert manifest["case_cites_case_edge_count"] == 0
     assert (output_dir / "graph_law_nodes.jsonl").exists()
     assert (output_dir / "graph_article_nodes.jsonl").exists()
+    assert (output_dir / "graph_case_nodes.jsonl").exists()
     assert (output_dir / "graph_edges_has_child_law.jsonl").exists()
     assert (output_dir / "graph_edges_delegates_to_law.jsonl").exists()
+    assert (output_dir / "graph_edges_case_related_to_law.jsonl").exists()
+    assert (output_dir / "graph_edges_case_related_to_article.jsonl").exists()
+    assert (output_dir / "graph_edges_case_cites_case.jsonl").exists()
     assert (output_dir / "graph_manifest.json").exists()

--- a/apps/backend/legal-pipeline/tests/test_law_graph_neo4j_seed.py
+++ b/apps/backend/legal-pipeline/tests/test_law_graph_neo4j_seed.py
@@ -1,6 +1,10 @@
 from src.common.io_utils import write_jsonl
 from src.export.law_graph_neo4j_seed import (
     ARTICLE_NODE_QUERY,
+    CASE_CITES_CASE_QUERY,
+    CASE_NODE_QUERY,
+    CASE_RELATED_TO_ARTICLE_QUERY,
+    CASE_RELATED_TO_LAW_QUERY,
     DELEGATES_TO_LAW_QUERY,
     HAS_ARTICLE_QUERY,
     HAS_CHILD_LAW_QUERY,
@@ -17,11 +21,15 @@ def test_load_graph_seed_rows_and_manifest(tmp_path):
     base_dir = tmp_path / "graph"
     write_jsonl([{"law_uid": "001"}], base_dir / "graph_law_nodes.jsonl")
     write_jsonl([{"article_uid": "article::001::1"}], base_dir / "graph_article_nodes.jsonl")
+    write_jsonl([{"canonical_case_id": "case::prec::1"}], base_dir / "graph_case_nodes.jsonl")
     write_jsonl([{"edge_id": "HAS_ARTICLE::001::article::001::1"}], base_dir / "graph_edges_has_article.jsonl")
     write_jsonl([{"edge_id": "HAS_CHILD_LAW::001::002"}], base_dir / "graph_edges_has_child_law.jsonl")
     write_jsonl([{"edge_id": "DELEGATES_TO_LAW::001::002"}], base_dir / "graph_edges_delegates_to_law.jsonl")
     write_jsonl([{"edge_id": "REFERS_TO_LAW::001::002"}], base_dir / "graph_edges_refers_to_law.jsonl")
     write_jsonl([{"edge_id": "REFERS_TO_ARTICLE::article::001::1::article::002::2"}], base_dir / "graph_edges_refers_to_article.jsonl")
+    write_jsonl([{"edge_id": "CASE_RELATED_TO_LAW::1"}], base_dir / "graph_edges_case_related_to_law.jsonl")
+    write_jsonl([{"edge_id": "CASE_RELATED_TO_ARTICLE::1"}], base_dir / "graph_edges_case_related_to_article.jsonl")
+    write_jsonl([{"edge_id": "CASE_CITES_CASE::1"}], base_dir / "graph_edges_case_cites_case.jsonl")
 
     rows = load_graph_seed_rows(base_dir)
     manifest = build_seed_manifest(rows)
@@ -29,11 +37,15 @@ def test_load_graph_seed_rows_and_manifest(tmp_path):
     assert manifest == {
         "law_node_count": 1,
         "article_node_count": 1,
+        "case_node_count": 1,
         "has_article_edge_count": 1,
         "has_child_law_edge_count": 1,
         "delegates_to_law_edge_count": 1,
         "refers_to_law_edge_count": 1,
         "refers_to_article_edge_count": 1,
+        "case_related_to_law_edge_count": 1,
+        "case_related_to_article_edge_count": 1,
+        "case_cites_case_edge_count": 1,
     }
 
 
@@ -41,20 +53,28 @@ def test_iter_seed_operations_returns_expected_query_order():
     rows = {
         "law_nodes": [{"law_uid": "001"}],
         "article_nodes": [{"article_uid": "article::001::1"}],
+        "case_nodes": [{"canonical_case_id": "case::prec::1"}],
         "has_article_edges": [{"edge_id": "HAS_ARTICLE::001::article::001::1"}],
         "has_child_law_edges": [{"edge_id": "HAS_CHILD_LAW::001::002"}],
         "delegates_to_law_edges": [{"edge_id": "DELEGATES_TO_LAW::001::002"}],
         "refers_to_law_edges": [{"edge_id": "REFERS_TO_LAW::001::002"}],
         "refers_to_article_edges": [{"edge_id": "REFERS_TO_ARTICLE::article::001::1::article::002::2"}],
+        "case_related_to_law_edges": [{"edge_id": "CASE_RELATED_TO_LAW::1"}],
+        "case_related_to_article_edges": [{"edge_id": "CASE_RELATED_TO_ARTICLE::1"}],
+        "case_cites_case_edges": [{"edge_id": "CASE_CITES_CASE::1"}],
     }
 
     operations = iter_seed_operations(rows)
     assert [query for query, _ in operations] == [
         LAW_NODE_QUERY,
         ARTICLE_NODE_QUERY,
+        CASE_NODE_QUERY,
         HAS_ARTICLE_QUERY,
         HAS_CHILD_LAW_QUERY,
         DELEGATES_TO_LAW_QUERY,
         REFERS_TO_LAW_QUERY,
         REFERS_TO_ARTICLE_QUERY,
+        CASE_RELATED_TO_LAW_QUERY,
+        CASE_RELATED_TO_ARTICLE_QUERY,
+        CASE_CITES_CASE_QUERY,
     ]


### PR DESCRIPTION
## Work Description
- 기존 neo4j 는 Law, Article 중심 Case 미포함
    - Law 노드 / Article shem / Law ↔ Law / Law ↔ Article / Article ↔ Article
- leagal_relation.jsonl 기반으로 case 노드와 관계 추가
    - Case 노드 / Case ↔ Law / Case ↔ Article / Case ↔ Case
    - leagal_relation row 데이터 반환 필드
- 이번 작업에서 text2Cypher, 프론트 그래프, RAG 검색은 다루지 않고 db 업데이트 만이 목적

## Changes
- 목표 

항목 | 설명
-- | --
Case 노드 | canonical_case_id 기준 사례 1건당 1노드
Case → Law | 사례와 법령 관계
Case → Article | 사례와 조문 관계
Case → Case | 사례 간 참조 관계

  -  text2Cypher, 프론트 그래프, RAG 검색 에서는 적용 x,  neo4j db 업데이트 

- 결과

항목 | 수
-- | --
Law nodes | 25
Article nodes | 1,144
Case nodes | 6,021
Case → Law | 6,930
Case → Article | 7,717
Case → Case | 4,702


<!-- notionvc: db140dea-922c-4f00-827a-75c52b148dc5 -->

<!-- notionvc: 674e0cd9-f102-4d7d-8b6c-5c6e9dc83d83 -->

## Testing
- [x] 업데이트 혹인 
- [x] 정합성 검증
- [x] RAG 검색 및 프론트 그래프 영향 없음 확인

## Related Issue
close #197
